### PR TITLE
Ignores coverage analysis of generated files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/zz_generated.deepcopy.go"


### PR DESCRIPTION
Files generated by kubebuilder make targets should not be evaluated.