### PR TITLE
Sets registry to blank during dev deployment

### DIFF
--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -118,6 +118,7 @@ function dco::helm_install() {
     $chart_name \
     deploy/helm/$chart_name \
     --install \
+    --set image.registry="" \
     --set image.repository="$IMAGE_NAME" \
     --set image.tag="$latest_tag" \
     --set config.logDevelopmentMode=true


### PR DESCRIPTION
We're not building an image with the "ghcr.io" prefix so we should remove this default.

/cc @ddl-audi 