### PR TITLE
Updating CI security

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Inspect env
+      run: |
+        env
+        exit 1
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,41 +22,41 @@ jobs:
 #      with:
 #        limit-access-to-actor: true
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16.2
+#    - name: Set up Go
+#      uses: actions/setup-go@v2
+#      with:
+#        go-version: 1.16.2
+#
+#    - name: Cache go modules and build data
+#      uses: actions/cache@v2
+#      with:
+#        path: |
+#          ~/go/pkg/mod
+#          ~/.cache/go-build
+#        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+#        restore-keys: |
+#          ${{ runner.os }}-go-
+#
+#    - name: Cache build tools
+#      uses: actions/cache@v2
+#      with:
+#        path: |
+#          bin
+#          testbin
+#        key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
 
-    - name: Cache go modules and build data
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/go/pkg/mod
-          ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Cache build tools
-      uses: actions/cache@v2
-      with:
-        path: |
-          bin
-          testbin
-        key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
-
-    - name: Build
-      run: make build
-
-    - name: Test
-      run: make test
-
-      # TODO: research golangci github action
-    - name: Lint
-      run: make lint
-
-    - name: Upload coverage report
-      uses: codecov/codecov-action@v1
+#    - name: Build
+#      run: make build
+#
+#    - name: Test
+#      run: make test
+#
+#      # TODO: research golangci github action
+#    - name: Lint
+#      run: make lint
+#
+#    - name: Upload coverage report
+#      uses: codecov/codecov-action@v1
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 15
+      with:
+        limit-access-to-actor: true
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,47 +16,41 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-#    - name: Setup tmate session
-#      uses: mxschmitt/action-tmate@v3
-#      timeout-minutes: 15
-#      with:
-#        limit-access-to-actor: true
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.2
 
-#    - name: Set up Go
-#      uses: actions/setup-go@v2
-#      with:
-#        go-version: 1.16.2
-#
-#    - name: Cache go modules and build data
-#      uses: actions/cache@v2
-#      with:
-#        path: |
-#          ~/go/pkg/mod
-#          ~/.cache/go-build
-#        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-#        restore-keys: |
-#          ${{ runner.os }}-go-
-#
-#    - name: Cache build tools
-#      uses: actions/cache@v2
-#      with:
-#        path: |
-#          bin
-#          testbin
-#        key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+    - name: Cache go modules and build data
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
-#    - name: Build
-#      run: make build
-#
-#    - name: Test
-#      run: make test
-#
-#      # TODO: research golangci github action
-#    - name: Lint
-#      run: make lint
-#
-#    - name: Upload coverage report
-#      uses: codecov/codecov-action@v1
+    - name: Cache build tools
+      uses: actions/cache@v2
+      with:
+        path: |
+          bin
+          testbin
+        key: ${{ runner.os }}-go-${{ hashFiles('Makefile') }}
+
+    - name: Build
+      run: make build
+
+    - name: Test
+      run: make test
+
+      # TODO: research golangci github action
+    - name: Lint
+      run: make lint
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v1
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.BOT_CR_PAT }}
 
     - name: Prepare Docker image
       id: docker_prep

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.BOT_CR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Prepare Docker image
       id: docker_prep

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 15
-      with:
-        limit-access-to-actor: true
+#    - name: Setup tmate session
+#      uses: mxschmitt/action-tmate@v3
+#      timeout-minutes: 15
+#      with:
+#        limit-access-to-actor: true
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -66,7 +66,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.BOT_CR_PAT }}
 
     - name: Prepare Docker image
       id: docker_prep
@@ -142,7 +142,7 @@ jobs:
           IMAGE="$(echo ${{ github.repository }} | awk -F / '{ print $(NF-1)  "/helm/" $NF }')"
           REF="$REGISTRY/$IMAGE:${{ needs.build.outputs.version }}"
 
-          ./scripts/release/helm.sh login -h "$REGISTRY" -u "${{ github.repository_owner }}" -p "${{ secrets.GITHUB_TOKEN }}"
+          ./scripts/release/helm.sh login -h "$REGISTRY" -u "${{ github.repository_owner }}" -p "${{ secrets.BOT_CR_PAT }}"
           ./scripts/release/helm.sh push -r "$REF"
 
       - name: Package and push chart to gcr.io
@@ -152,5 +152,5 @@ jobs:
           REF="$REGISTRY/$IMAGE:${{ needs.build.outputs.version }}"
           PASSWORD="$(echo ${{ secrets.GCR_PASSWORD }} | base64 --decode)"
 
-          ./scripts/release/helm.sh login -h "$REGISTRY" -n "${{ secrets.GCR_NAMESPACE }}" -u _json_key -p "$PASSWORD"
+          ./scripts/release/helm.sh login -h "$REGISTRY" -n "${{ secrets.GCR_NAMESPACE }}" -u "${{ secrets.GCR_USERNAME }}" -p "$PASSWORD"
           ./scripts/release/helm.sh push -r "$REF"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Inspect env
-      run: |
-        env
-        exit 1
-
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -65,7 +60,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
-        password: ${{ secrets.CR_PAT }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Prepare Docker image
       id: docker_prep
@@ -141,7 +136,7 @@ jobs:
           IMAGE="$(echo ${{ github.repository }} | awk -F / '{ print $(NF-1)  "/helm/" $NF }')"
           REF="$REGISTRY/$IMAGE:${{ needs.build.outputs.version }}"
 
-          ./scripts/release/helm.sh login -h "$REGISTRY" -u "${{ github.repository_owner }}" -p "${{ secrets.CR_PAT }}"
+          ./scripts/release/helm.sh login -h "$REGISTRY" -u "${{ github.repository_owner }}" -p "${{ secrets.GITHUB_TOKEN }}"
           ./scripts/release/helm.sh push -r "$REF"
 
       - name: Package and push chart to gcr.io


### PR DESCRIPTION
In response to recent Codecov security breach, all existing credentials were delete and re-created with the following changes:

- Leverages new, limited bot PAT for GHCR registry access ( we should be able to use a short-lived `GITHUB_TOKEN` for access according to the docs but I haven't had any success there; will follow up with a separate test to try and make this work ).
- Uses dedicated and limited GCR credentials for DCO chart storage.

Configuration happened behind the scenes so there are no real appreciable changes to the code.