### PR TITLE
Exposing DCO metrics to metric consumers

### DIFF
--- a/deploy/helm/distributed-compute-operator/templates/deployment.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/deployment.yaml
@@ -13,12 +13,19 @@ spec:
     type: Recreate
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+      {{- if .Values.prometheus.enabled }}
+        prometheus.io/port: "{{ .Values.config.metricsPort }}"
+        prometheus.io/scrape: "true"
+      {{- end }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       labels:
         {{- include "common.labels.matchLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+          {{- toYaml . | trimSuffix "\n" | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/deploy/helm/distributed-compute-operator/templates/networkpolicy.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/networkpolicy.yaml
@@ -17,6 +17,16 @@ spec:
       protocol: TCP
     - port: {{ .Values.config.healthProbePort }}
       protocol: TCP
+  - ports:
     - port: {{ .Values.config.metricsPort }}
       protocol: TCP
+    from:
+    - podSelector:
+        matchLabels:
+          {{- toYaml .Values.prometheus.podLabels | trimSuffix "\n" | nindent 10 }}
+      {{- with .Values.prometheus.namespaceLabels }}
+      namespaceSelector:
+        matchLabels:
+          {{- toYaml . | trimSuffix "\n" | nindent 10 }}
+      {{- end }}
 {{- end }}

--- a/deploy/helm/distributed-compute-operator/values.yaml
+++ b/deploy/helm/distributed-compute-operator/values.yaml
@@ -42,7 +42,16 @@ podSecurityPolicy:
 
 networkPolicy:
   # Restrict network ingress to operator pods
+  enabled: false
+
+prometheus:
+  # Enable prometheus scraping
   enabled: true
+  # Allow ingress traffic from prometheus pods with the following labels
+  podLabels:
+    app.kubernetes.io/name: prometheus
+  # Namespace labels where prometheus is running if different from app's namespace
+  namespaceLabels: {}
 
 image:
   registry: ghcr.io
@@ -62,8 +71,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+podLabels: {}
 podAnnotations: {}
-
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
### Changes

- updates network policy metrics port
- adds prometheus annotations to operator pods
- adds `podLabels' value for added configurability