### PR TITLE
helm chart: support priority class name setting

### DIFF
--- a/deploy/helm/distributed-compute-operator/templates/deployment.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/deployment.yaml
@@ -107,3 +107,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}

--- a/deploy/helm/distributed-compute-operator/values.yaml
+++ b/deploy/helm/distributed-compute-operator/values.yaml
@@ -102,5 +102,7 @@ tolerations: []
 
 affinity: {}
 
+priorityClassName: ""
+
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Allow cluster-wide pod priority & preemption settings (though it likely won't impact DCO much).