### PR TITLE
PLAT-2322: Specify worker-port-list only if worker ports are defined

### DIFF
--- a/api/v1alpha1/raycluster_webhook.go
+++ b/api/v1alpha1/raycluster_webhook.go
@@ -28,7 +28,6 @@ var (
 	rayDefaultNodeManagerPort     int32 = 2385
 	rayDefaultGCSServerPort       int32 = 2386
 	rayDefaultDashboardPort       int32 = 8265
-	rayDefaultWorkerPorts               = []int32{11_000, 11_001, 11_002, 11_003, 11_004}
 	rayDefaultRedisShardPorts           = []int32{6380, 6381}
 	rayDefaultEnableDashboard           = pointer.BoolPtr(true)
 	rayDefaultEnableNetworkPolicy       = pointer.BoolPtr(true)
@@ -81,10 +80,6 @@ func (r *RayCluster) Default() {
 	if r.Spec.GCSServerPort == 0 {
 		log.Info("setting default gcs server port", "value", rayDefaultGCSServerPort)
 		r.Spec.GCSServerPort = rayDefaultGCSServerPort
-	}
-	if r.Spec.WorkerPorts == nil {
-		log.Info("setting default worker ports", "value", rayDefaultWorkerPorts)
-		r.Spec.WorkerPorts = rayDefaultWorkerPorts
 	}
 	if r.Spec.NodeManagerPort == 0 {
 		log.Info("setting default node manager port", "value", rayDefaultNodeManagerPort)

--- a/api/v1alpha1/raycluster_webhook_integration_test.go
+++ b/api/v1alpha1/raycluster_webhook_integration_test.go
@@ -65,10 +65,6 @@ var _ = Describe("RayCluster", func() {
 				BeNumerically("==", 2386),
 				"gcs server port should equal 2386",
 			)
-			Expect(rc.Spec.WorkerPorts).To(
-				Equal([]int32{11000, 11001, 11002, 11003, 11004}),
-				"worker ports should equal [11000, 11001, 11002, 11003, 11004]",
-			)
 			Expect(rc.Spec.DashboardPort).To(
 				BeNumerically("==", 8265),
 				"dashboard port should equal 8265",

--- a/pkg/resources/ray/statefulset.go
+++ b/pkg/resources/ray/statefulset.go
@@ -318,7 +318,10 @@ func processArgs(rc *dcv1alpha1.RayCluster) []string {
 		"--num-cpus=$(MY_CPU_REQUEST)",
 		fmt.Sprintf("--object-manager-port=%d", rc.Spec.ObjectManagerPort),
 		fmt.Sprintf("--node-manager-port=%d", rc.Spec.NodeManagerPort),
-		fmt.Sprintf("--worker-port-list=%s", strings.Join(util.IntsToStrings(rc.Spec.WorkerPorts), ",")),
+	}
+
+	if rc.Spec.WorkerPorts != nil {
+		args = append(args, fmt.Sprintf("--worker-port-list=%s", strings.Join(util.IntsToStrings(rc.Spec.WorkerPorts), ",")))
 	}
 
 	if rc.Spec.ObjectStoreMemoryBytes != nil {


### PR DESCRIPTION
### What problem does this PR solve?
To enable Istio for Ray, the Distributed Compute Operator replaces random worker ports with static ones and defaults to 5 worker ports.  This means that only up to 5 worker processes are allowed per worker pod.  This causes Ray programs to fail if they try to schedule more than 5 worker processes based on the resource requirements and the amount of cpu/gpu available in the hardware tiers.

https://github.com/cerebrotech/domino/pull/24018 addresses this by configuring the worker port list to 100 ports by default (worker port range configurable in Central Config) across all deployments.

For non-Istio deployments, we should not specify any static worker ports at all (which is only required for Istio deployments). 

### What is the solution?
- Nucleus will configure `spec.workerPorts` for Istio deployments only
- Remove default worker ports
- Specify worker-port-list only if worker ports are defined

https://dominodatalab.atlassian.net/browse/PLAT-2322