### PR TITLE
Rename http-dashboard to tcp-dashboard, so that istio can proxy requests with Upgrade and Connection headers on them

### DIFF
--- a/pkg/resources/ray/service.go
+++ b/pkg/resources/ray/service.go
@@ -24,7 +24,7 @@ func NewClientService(rc *dcv1alpha1.RayCluster) *corev1.Service {
 
 	if util.BoolPtrIsTrue(rc.Spec.EnableDashboard) {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "http-dashboard",
+			Name:       "tcp-dashboard",
 			Port:       rc.Spec.DashboardPort,
 			TargetPort: intstr.FromInt(int(rc.Spec.DashboardPort)),
 		})

--- a/pkg/resources/ray/service_test.go
+++ b/pkg/resources/ray/service_test.go
@@ -48,7 +48,7 @@ func TestNewClientService(t *testing.T) {
 		svc := NewClientService(rc)
 
 		expected.Spec.Ports = append(expected.Spec.Ports, corev1.ServicePort{
-			Name:       "http-dashboard",
+			Name:       "tcp-dashboard",
 			Port:       8265,
 			TargetPort: intstr.FromInt(8265),
 		})


### PR DESCRIPTION
# Problem

The general compute cluster rules don't support request upgrading. The dask dashboard requires http request upgrading, because it uses websockets (the rules work for the dask dashboard otherwise, AFAICT).

However, proxy passing these headers in the nginx rules makes istio unable to proxy requests to the ray dashboard. Even if the connection and upgrade headers are correct for normal http requests, istio cannot find a place to send them.

This breaks viewing of the ray dashboard on istio deployments, because requests to the ray dashboard are proxied using the general compute cluster rules. We need these rules to support the dask dashboard (these changes: https://github.com/cerebrotech/charts/pull/874). Therefore, we must make it so that the ray dashboard is viewable at all times, even when Upgrade and Connection headers are present.

# Solution

Rename the `http-dashboard` port on the ray-client svc to `tcp-dashboard`. This seems to make istio's routing rules for these requests more general.

I couldn't find any information on this particular problem, so I can only say what I think is happening:  TCP has control over data streaming and how things are transported. Maybe istio has chosen to carry this distinction into how it divines what kind of endpoints/routes/listeners should be created for things named with "http" vs things name with "tcp".

# Future Consequences

All k8s svcs with port specifications that forward requests to compute cluster dashboards that use the general compute cluster rules must have that port named as `tcp` or prefixed with `tcp-`. 

# Testing
## manual testing
I manually tested this by update a dco deploy with an image with this PR's changes in a fcmd deployment with istio CNI/default on it, adding Upgrade and Connection headers to the general compute cluster dashboard proxying rules in the nucleus-nginx conf, starting a ray workspace, and verifying that I could see the dashboard via the tab in the workspace.

## automated testing

I didn't create any automated tests for this. This would be covered by integration testing a deployment set up with istio and viewing a ray dashboard through the workspace UI.

# JIRA

https://dominodatalab.atlassian.net/browse/DOM-28403