### PR TITLE
Adding dominodatalab.com labels to Service, NetworkPolicy to Spark DCO

### DIFF
--- a/pkg/resources/spark/networkpolicy.go
+++ b/pkg/resources/spark/networkpolicy.go
@@ -27,7 +27,7 @@ func NewClusterWorkerNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, ComponentWorker),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabels(sc), sc.Spec.Worker.Labels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "worker network policy",
 			},
@@ -73,7 +73,7 @@ func NewClusterDriverNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, "driver"),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabels(sc), sc.Spec.Master.Labels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "driver network policy",
 			},
@@ -140,7 +140,7 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, "master"),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabels(sc), sc.Spec.Master.Labels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "master network policy",
 			},

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -39,7 +39,7 @@ func NewMasterService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MasterServiceName(sc.Name),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabelsWithComponent(sc, ComponentMaster),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabelsWithComponent(sc, ComponentMaster), sc.Spec.Master.Labels),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -55,7 +55,7 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      HeadlessServiceName(sc.Name),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabelsWithComponent(sc, ComponentWorker),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabelsWithComponent(sc, ComponentWorker), sc.Spec.Worker.Labels),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
@@ -91,7 +91,7 @@ func NewSparkDriverService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DriverServiceName(sc.Spec.Driver.SparkClusterName),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    MetadataAndAdditionalLabels(MetadataLabels(sc), sc.Spec.Master.Labels),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,

--- a/pkg/resources/spark/spark.go
+++ b/pkg/resources/spark/spark.go
@@ -3,6 +3,8 @@ package spark
 import (
 	"fmt"
 
+	"github.com/dominodatalab/distributed-compute-operator/pkg/util"
+
 	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
 	"github.com/dominodatalab/distributed-compute-operator/pkg/resources"
 )
@@ -59,6 +61,14 @@ func MetadataLabels(sc *dcv1alpha1.SparkCluster) map[string]string {
 // MetadataLabelsWithComponent returns standard component metadata for spark resources.
 func MetadataLabelsWithComponent(sc *dcv1alpha1.SparkCluster, comp Component) map[string]string {
 	return resources.MetadataLabelsWithComponent(ApplicationName, sc.Name, sc.Spec.Image.Tag, string(comp))
+}
+
+// MetadataLabelsWithComponent returns standard component metadata for spark resources.
+func MetadataAndAdditionalLabels(labels map[string]string, extraLabels map[string]string) map[string]string {
+	if extraLabels != nil {
+		labels = util.MergeStringMaps(extraLabels, labels)
+	}
+	return labels
 }
 
 // SelectorLabels returns a resource selector clause for spark resources.

--- a/pkg/resources/spark/statefulset.go
+++ b/pkg/resources/spark/statefulset.go
@@ -60,7 +60,7 @@ func NewStatefulSet(sc *dcv1alpha1.SparkCluster, comp Component) (*appsv1.Statef
 		return nil, err
 	}
 
-	labels := processLabels(sc, comp, nodeAttrs.Labels)
+	labels := MetadataAndAdditionalLabels(MetadataLabelsWithComponent(sc, comp), nodeAttrs.Labels)
 	envVars := append(componentEnvVars(sc, comp), sc.Spec.EnvVars...)
 	volumes = nodeAttrs.Volumes
 	volumeMounts = nodeAttrs.VolumeMounts
@@ -295,12 +295,4 @@ func componentEnvVars(sc *dcv1alpha1.SparkCluster, comp Component) []corev1.EnvV
 		}
 	}
 	return envVar
-}
-
-func processLabels(sc *dcv1alpha1.SparkCluster, comp Component, extraLabels map[string]string) map[string]string {
-	labels := MetadataLabelsWithComponent(sc, comp)
-	if extraLabels != nil {
-		labels = util.MergeStringMaps(extraLabels, labels)
-	}
-	return labels
 }


### PR DESCRIPTION
Ensure the correct `dominodatalab.com` labels exist on the correct K8s resources for DCO Spark