### PR TITLE
Adding global labels to DCO Spark

### DIFF
--- a/api/v1alpha1/sparkcluster_types.go
+++ b/api/v1alpha1/sparkcluster_types.go
@@ -100,6 +100,8 @@ type SparkClusterSpec struct {
 	// ImagePullSecrets are references to secrets with credentials to private registries used to pull images.
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 
+	GlobalLabels map[string]string `json:"globalLabels,omitempty"`
+
 	// ClusterPort is the port on which the spark protocol communicates
 	ClusterPort int32 `json:"clusterPort,omitempty"`
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -936,6 +936,13 @@ func (in *SparkClusterSpec) DeepCopyInto(out *SparkClusterSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.GlobalLabels != nil {
+		in, out := &in.GlobalLabels, &out.GlobalLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.IstioConfig = in.IstioConfig
 	out.Driver = in.Driver
 	if in.EnableDashboard != nil {

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.v1beta1.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.v1beta1.yaml
@@ -207,6 +207,10 @@ spec:
                 - name
                 type: object
               type: array
+            globalLabels:
+              additionalProperties:
+                type: string
+              type: object
             image:
               description: Image used to launch master and worker nodes.
               properties:

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
@@ -202,6 +202,10 @@ spec:
                   - name
                   type: object
                 type: array
+              globalLabels:
+                additionalProperties:
+                  type: string
+                type: object
               image:
                 description: Image used to launch master and worker nodes.
                 properties:

--- a/config/samples/distributed-compute_v1alpha1_sparkcluster.yaml
+++ b/config/samples/distributed-compute_v1alpha1_sparkcluster.yaml
@@ -4,6 +4,7 @@ metadata:
   name: example
 spec:
   ## global configurations
+  # globalLabels: {}
 
   # image used by head and worker pods
   image:

--- a/pkg/resources/spark/configmap.go
+++ b/pkg/resources/spark/configmap.go
@@ -27,7 +27,7 @@ func NewFrameworkConfigMap(sc *dcv1alpha1.SparkCluster) *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      FrameworkConfigMapName(sc.Name, ComponentNone),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		Data: data,
 	}
@@ -49,7 +49,7 @@ func NewKeyTabConfigMap(sc *dcv1alpha1.SparkCluster) *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      KeyTabConfigMapName(sc.Name, ComponentNone),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		BinaryData: binaryData,
 	}

--- a/pkg/resources/spark/horizontalpodautoscaler.go
+++ b/pkg/resources/spark/horizontalpodautoscaler.go
@@ -63,6 +63,6 @@ func HorizontalPodAutoscalerObjectMeta(sc *dcv1alpha1.SparkCluster) metav1.Objec
 	return metav1.ObjectMeta{
 		Name:      InstanceObjectName(sc.Name, ComponentNone),
 		Namespace: sc.Namespace,
-		Labels:    MetadataLabels(sc),
+		Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 	}
 }

--- a/pkg/resources/spark/networkpolicy.go
+++ b/pkg/resources/spark/networkpolicy.go
@@ -27,7 +27,7 @@ func NewClusterWorkerNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, ComponentWorker),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "worker network policy",
 			},
@@ -73,7 +73,7 @@ func NewClusterDriverNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, "driver"),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "driver network policy",
 			},
@@ -140,7 +140,7 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, "master"),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 			Annotations: map[string]string{
 				resources.DescriptionAnnotationKey: "master network policy",
 			},

--- a/pkg/resources/spark/podsecuritypolicy.go
+++ b/pkg/resources/spark/podsecuritypolicy.go
@@ -22,7 +22,7 @@ func NewPodSecurityPolicyRBAC(sc *dcv1alpha1.SparkCluster) (*rbacv1.Role, *rbacv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
@@ -38,7 +38,7 @@ func NewPodSecurityPolicyRBAC(sc *dcv1alpha1.SparkCluster) (*rbacv1.Role, *rbacv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -39,7 +39,7 @@ func NewMasterService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      MasterServiceName(sc.Name),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabelsWithComponent(sc, ComponentMaster),
+			Labels:    AddGlobalLabels(MetadataLabelsWithComponent(sc, ComponentMaster), sc.Spec.GlobalLabels),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -55,7 +55,7 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      HeadlessServiceName(sc.Name),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabelsWithComponent(sc, ComponentWorker),
+			Labels:    AddGlobalLabels(MetadataLabelsWithComponent(sc, ComponentWorker), sc.Spec.GlobalLabels),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
@@ -91,7 +91,7 @@ func NewSparkDriverService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DriverServiceName(sc.Spec.Driver.SparkClusterName),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,

--- a/pkg/resources/spark/serviceaccount.go
+++ b/pkg/resources/spark/serviceaccount.go
@@ -14,7 +14,7 @@ func NewServiceAccount(sc *dcv1alpha1.SparkCluster) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      InstanceObjectName(sc.Name, ComponentNone),
 			Namespace: sc.Namespace,
-			Labels:    MetadataLabels(sc),
+			Labels:    AddGlobalLabels(MetadataLabels(sc), sc.Spec.GlobalLabels),
 		},
 		AutomountServiceAccountToken: pointer.BoolPtr(false),
 	}

--- a/pkg/resources/spark/spark.go
+++ b/pkg/resources/spark/spark.go
@@ -3,6 +3,8 @@ package spark
 import (
 	"fmt"
 
+	"github.com/dominodatalab/distributed-compute-operator/pkg/util"
+
 	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
 	"github.com/dominodatalab/distributed-compute-operator/pkg/resources"
 )
@@ -59,6 +61,13 @@ func MetadataLabels(sc *dcv1alpha1.SparkCluster) map[string]string {
 // MetadataLabelsWithComponent returns standard component metadata for spark resources.
 func MetadataLabelsWithComponent(sc *dcv1alpha1.SparkCluster, comp Component) map[string]string {
 	return resources.MetadataLabelsWithComponent(ApplicationName, sc.Name, sc.Spec.Image.Tag, string(comp))
+}
+
+func AddGlobalLabels(labels map[string]string, globalLabels map[string]string) map[string]string {
+	if globalLabels != nil {
+		labels = util.MergeStringMaps(globalLabels, labels)
+	}
+	return labels
 }
 
 // SelectorLabels returns a resource selector clause for spark resources.

--- a/pkg/resources/spark/statefulset.go
+++ b/pkg/resources/spark/statefulset.go
@@ -60,7 +60,7 @@ func NewStatefulSet(sc *dcv1alpha1.SparkCluster, comp Component) (*appsv1.Statef
 		return nil, err
 	}
 
-	labels := processLabels(sc, comp, nodeAttrs.Labels)
+	labels := AddGlobalLabels(MetadataLabelsWithComponent(sc, comp), nodeAttrs.Labels)
 	envVars := append(componentEnvVars(sc, comp), sc.Spec.EnvVars...)
 	volumes = nodeAttrs.Volumes
 	volumeMounts = nodeAttrs.VolumeMounts
@@ -295,12 +295,4 @@ func componentEnvVars(sc *dcv1alpha1.SparkCluster, comp Component) []corev1.EnvV
 		}
 	}
 	return envVar
-}
-
-func processLabels(sc *dcv1alpha1.SparkCluster, comp Component, extraLabels map[string]string) map[string]string {
-	labels := MetadataLabelsWithComponent(sc, comp)
-	if extraLabels != nil {
-		labels = util.MergeStringMaps(extraLabels, labels)
-	}
-	return labels
 }


### PR DESCRIPTION
Spark services and network policies are missing `dominodatalab.com` labels.