### PR TITLE
Fix Autoscaling AverageCPUUtilization

### DIFF
--- a/pkg/cluster/dask/horizonalpodautoscaler.go
+++ b/pkg/cluster/dask/horizonalpodautoscaler.go
@@ -45,15 +45,9 @@ func (s *horizontalPodAutoscalerDS) HorizontalPodAutoscaler() *autoscalingv2beta
 		}
 	}
 
-	hpa.Spec = autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-		ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
-			Kind:       s.dc.Kind,
-			Name:       s.dc.Name,
-			APIVersion: s.dc.APIVersion,
-		},
-		MinReplicas: s.dc.Spec.Autoscaling.MinReplicas,
-		MaxReplicas: s.dc.Spec.Autoscaling.MaxReplicas,
-		Metrics: []autoscalingv2beta2.MetricSpec{
+	var metrics []autoscalingv2beta2.MetricSpec
+	if as.AverageCPUUtilization != nil {
+		metrics = []autoscalingv2beta2.MetricSpec{
 			{
 				Type: autoscalingv2beta2.ResourceMetricSourceType,
 				Resource: &autoscalingv2beta2.ResourceMetricSource{
@@ -64,8 +58,19 @@ func (s *horizontalPodAutoscalerDS) HorizontalPodAutoscaler() *autoscalingv2beta
 					},
 				},
 			},
+		}
+	}
+
+	hpa.Spec = autoscalingv2beta2.HorizontalPodAutoscalerSpec{
+		ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			Kind:       s.dc.Kind,
+			Name:       s.dc.Name,
+			APIVersion: s.dc.APIVersion,
 		},
-		Behavior: behavior,
+		MinReplicas: s.dc.Spec.Autoscaling.MinReplicas,
+		MaxReplicas: s.dc.Spec.Autoscaling.MaxReplicas,
+		Metrics:     metrics,
+		Behavior:    behavior,
 	}
 
 	return hpa

--- a/pkg/resources/ray/horizontalpodautoscaler.go
+++ b/pkg/resources/ray/horizontalpodautoscaler.go
@@ -3,8 +3,9 @@ package ray
 import (
 	"fmt"
 
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
+
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
@@ -30,6 +31,22 @@ func NewHorizontalPodAutoscaler(rc *dcv1alpha1.RayCluster) (*autoscalingv2beta2.
 		}
 	}
 
+	var metrics []autoscalingv2beta2.MetricSpec
+	if autoscaling.AverageCPUUtilization != nil {
+		metrics = []autoscalingv2beta2.MetricSpec{
+			{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
+					Name: corev1.ResourceCPU,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
+						AverageUtilization: autoscaling.AverageCPUUtilization,
+					},
+				},
+			},
+		}
+	}
+
 	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: HorizontalPodAutoscalerObjectMeta(rc),
 		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
@@ -40,19 +57,8 @@ func NewHorizontalPodAutoscaler(rc *dcv1alpha1.RayCluster) (*autoscalingv2beta2.
 			},
 			MinReplicas: autoscaling.MinReplicas,
 			MaxReplicas: autoscaling.MaxReplicas,
-			Metrics: []autoscalingv2beta2.MetricSpec{
-				{
-					Type: autoscalingv2beta2.ResourceMetricSourceType,
-					Resource: &autoscalingv2beta2.ResourceMetricSource{
-						Name: corev1.ResourceCPU,
-						Target: autoscalingv2beta2.MetricTarget{
-							Type:               autoscalingv2beta2.UtilizationMetricType,
-							AverageUtilization: autoscaling.AverageCPUUtilization,
-						},
-					},
-				},
-			},
-			Behavior: behavior,
+			Metrics:     metrics,
+			Behavior:    behavior,
 		},
 	}
 

--- a/pkg/resources/ray/horizontalpodautoscaler_test.go
+++ b/pkg/resources/ray/horizontalpodautoscaler_test.go
@@ -38,18 +38,7 @@ func TestNewHorizontalPodAutoscaler(t *testing.T) {
 				},
 				MinReplicas: nil,
 				MaxReplicas: 0,
-				Metrics: []autoscalingv2beta2.MetricSpec{
-					{
-						Type: "Resource",
-						Resource: &autoscalingv2beta2.ResourceMetricSource{
-							Name: "cpu",
-							Target: autoscalingv2beta2.MetricTarget{
-								Type:               "Utilization",
-								AverageUtilization: nil,
-							},
-						},
-					},
-				},
+				Metrics:     nil,
 			},
 		}
 		assert.Equal(t, expected, actual)

--- a/pkg/resources/spark/horizontalpodautoscaler.go
+++ b/pkg/resources/spark/horizontalpodautoscaler.go
@@ -29,6 +29,22 @@ func NewHorizontalPodAutoscaler(sc *dcv1alpha1.SparkCluster) (*autoscalingv2beta
 		}
 	}
 
+	var metrics []autoscalingv2beta2.MetricSpec
+	if autoscaling.AverageCPUUtilization != nil {
+		metrics = []autoscalingv2beta2.MetricSpec{
+			{
+				Type: autoscalingv2beta2.ResourceMetricSourceType,
+				Resource: &autoscalingv2beta2.ResourceMetricSource{
+					Name: corev1.ResourceCPU,
+					Target: autoscalingv2beta2.MetricTarget{
+						Type:               autoscalingv2beta2.UtilizationMetricType,
+						AverageUtilization: autoscaling.AverageCPUUtilization,
+					},
+				},
+			},
+		}
+	}
+
 	hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{
 		ObjectMeta: HorizontalPodAutoscalerObjectMeta(sc),
 		Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
@@ -39,19 +55,8 @@ func NewHorizontalPodAutoscaler(sc *dcv1alpha1.SparkCluster) (*autoscalingv2beta
 			},
 			MinReplicas: autoscaling.MinReplicas,
 			MaxReplicas: autoscaling.MaxReplicas,
-			Metrics: []autoscalingv2beta2.MetricSpec{
-				{
-					Type: autoscalingv2beta2.ResourceMetricSourceType,
-					Resource: &autoscalingv2beta2.ResourceMetricSource{
-						Name: corev1.ResourceCPU,
-						Target: autoscalingv2beta2.MetricTarget{
-							Type:               autoscalingv2beta2.UtilizationMetricType,
-							AverageUtilization: autoscaling.AverageCPUUtilization,
-						},
-					},
-				},
-			},
-			Behavior: behavior,
+			Metrics:     metrics,
+			Behavior:    behavior,
 		},
 	}
 

--- a/pkg/resources/spark/horizontalpodautoscaler_test.go
+++ b/pkg/resources/spark/horizontalpodautoscaler_test.go
@@ -38,18 +38,7 @@ func TestNewHorizontalPodAutoscaler(t *testing.T) {
 				},
 				MinReplicas: nil,
 				MaxReplicas: 0,
-				Metrics: []autoscalingv2beta2.MetricSpec{
-					{
-						Type: "Resource",
-						Resource: &autoscalingv2beta2.ResourceMetricSource{
-							Name: "cpu",
-							Target: autoscalingv2beta2.MetricTarget{
-								Type:               "Utilization",
-								AverageUtilization: nil,
-							},
-						},
-					},
-				},
+				Metrics:     nil,
 			},
 		}
 		assert.Equal(t, expected, actual)


### PR DESCRIPTION
Autoscaling `AverageCPUUtilization` was previously an optional value, and had been made mandatory through recent changes. This fix converts it back into an optional value.

Tested against my local.