### PR TITLE
 Add the ability to install Istio to `scripts/development.sh'

### DIFF
--- a/istio/global-strict-mtls.yaml
+++ b/istio/global-strict-mtls.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mtls:
+    mode: STRICT

--- a/istio/operator-minimal.yaml
+++ b/istio/operator-minimal.yaml
@@ -1,0 +1,171 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    base:
+      enabled: true
+    cni: # changed
+      enabled: true
+      namespace: kube-system
+    egressGateways:
+    - enabled: false
+      name: istio-egressgateway
+    ingressGateways:
+    - enabled: false
+      name: istio-ingressgateway
+    istiodRemote:
+      enabled: false
+    pilot:
+      enabled: true
+  hub: docker.io/istio
+  meshConfig: # changed
+    accessLogFile: /dev/stdout
+    enableTracing: true
+    defaultConfig:
+      proxyMetadata: {}
+      holdApplicationUntilProxyStarts: true
+    enablePrometheusMerge: true
+  profile: minimal
+#  tag: 1.10.2
+  values:
+    cni: # changed
+      logLevel: info
+      excludeNamespaces:
+        - istio-system
+        - kube-system
+    sidecarInjectorWebhook:
+      rewriteAppHTTPProbe: true
+    base:
+      enableCRDTemplates: false
+      validationURL: ""
+    gateways:
+      istio-egressgateway:
+        autoscaleEnabled: true
+        env: {}
+        name: istio-egressgateway
+        secretVolumes:
+        - mountPath: /etc/istio/egressgateway-certs
+          name: egressgateway-certs
+          secretName: istio-egressgateway-certs
+        - mountPath: /etc/istio/egressgateway-ca-certs
+          name: egressgateway-ca-certs
+          secretName: istio-egressgateway-ca-certs
+        type: ClusterIP
+        zvpn: {}
+      istio-ingressgateway:
+        autoscaleEnabled: true
+        env: {}
+        name: istio-ingressgateway
+        secretVolumes:
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          secretName: istio-ingressgateway-certs
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          secretName: istio-ingressgateway-ca-certs
+        type: LoadBalancer
+        zvpn: {}
+    global:
+      configValidation: true
+      defaultNodeSelector: {}
+      defaultPodDisruptionBudget:
+        enabled: true
+      defaultResources:
+        requests:
+          cpu: 10m
+      imagePullPolicy: ""
+      imagePullSecrets: []
+      istioNamespace: istio-system
+      istiod:
+        enableAnalysis: false
+      jwtPolicy: third-party-jwt
+      logAsJson: false
+      logging:
+        level: default:info
+      meshNetworks: {}
+      mountMtlsCerts: false
+      multiCluster:
+        clusterName: ""
+        enabled: false
+      network: ""
+      omitSidecarInjectorConfigMap: false
+      oneNamespace: false
+      operatorManageWebhooks: false
+      pilotCertProvider: istiod
+      priorityClassName: ""
+      proxy:
+        autoInject: enabled
+        clusterDomain: cluster.local
+        componentLogLevel: misc:error
+        enableCoreDump: false
+        excludeIPRanges: ""
+        excludeInboundPorts: ""
+        excludeOutboundPorts: ""
+        image: proxyv2
+        includeIPRanges: '*'
+        logLevel: warning
+        privileged: false
+        readinessFailureThreshold: 30
+        readinessInitialDelaySeconds: 1
+        readinessPeriodSeconds: 2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        statusPort: 15020
+        tracer: zipkin
+      proxy_init:
+        image: proxyv2
+        resources:
+          limits:
+            cpu: 2000m
+            memory: 1024Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+      sds:
+        token:
+          aud: istio-ca
+      sts:
+        servicePort: 0
+      tracer:
+        datadog: {}
+        lightstep: {}
+        stackdriver: {}
+        zipkin: {}
+      useMCP: false
+    istiodRemote:
+      injectionURL: ""
+    pilot:
+      autoscaleEnabled: true
+      autoscaleMax: 5
+      autoscaleMin: 1
+      configMap: true
+      cpu:
+        targetAverageUtilization: 80
+      enableProtocolSniffingForInbound: true
+      enableProtocolSniffingForOutbound: true
+      env: {}
+      image: pilot
+      keepaliveMaxServerConnectionAge: 30m
+      nodeSelector: {}
+      replicaCount: 1
+      traceSampling: 1
+    telemetry:
+      enabled: true
+      v2:
+        enabled: true
+        metadataExchange:
+          wasmEnabled: false
+        prometheus:
+          enabled: true
+          wasmEnabled: false
+        stackdriver:
+          configOverride: {}
+          enabled: false
+          logging: false
+          monitoring: false
+          topology: false

--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -2,7 +2,7 @@
 #
 # A collection of functions to aid with development efforts.
 
-set -euo pipefail
+set -eo pipefail
 
 MINIKUBE_PROFILE=${MINIKUBE_PROFILE:-"distributed-compute-operator"}
 MINIKUBE_CPUS=${MINIKUBE_CPUS:-"6"}
@@ -10,6 +10,7 @@ MINIKUBE_MEMORY=${MINIKUBE_MEMORY:-"16384"}
 MINIKUBE_DISK_SIZE=${MINIKUBE_DISK_SIZE:-"50000mb"}
 IMAGE_NAME=${IMAGE_NAME:-"distributed-compute-operator"}
 IMAGE_TAG_PREFIX=${IMAGE_TAG_PREFIX:-"dev-"}
+ISTIOCTL_VERSION=${ISTIOCTL_VERSION:-1.10.2}
 
 function dco::_info {
   echo -e "\033[0;32m[development-workflow]\033[0m INFO: $*"
@@ -30,7 +31,8 @@ function dco::minikube_setup() {
       --driver=hyperkit \
       --addons=pod-security-policy \
       --extra-config=apiserver.enable-admission-plugins=PodSecurityPolicy \
-      --cni=calico
+      --cni=calico \
+      --network-plugin=cni
   elif minikube status --profile="$MINIKUBE_PROFILE" | grep -q 'host: Stopped'; then
     dco::_info "Restarting minikube cluster"
     minikube start --profile="$MINIKUBE_PROFILE"
@@ -123,6 +125,38 @@ function dco::helm_install() {
     --set config.logDevelopmentMode=true
 }
 
+dco::install_istio() {
+  local bin=bin/istioctl
+
+  if [[ -f $bin ]] && [[ $($bin version) =~ client\ version:\ $ISTIOCTL_VERSION ]]; then
+    dco::_info "Istioctl is present"
+  else
+    dco::_info "Downloading istioctl"
+
+    local osarch="osx"
+    if [[ $(uname -s) == "Linux" ]]; then
+      osarch="linux-amd64"
+    fi
+
+    curl -sLS "https://github.com/istio/istio/releases/download/$ISTIOCTL_VERSION/istioctl-$ISTIOCTL_VERSION-$osarch.tar.gz" \
+      | tar -xz -C ./bin
+  fi
+
+  local operator_manifest=istio/operator-minimal.yaml
+  if $bin verify-install -f $operator_manifest 1> /dev/null && [[ $($bin version) =~ control\ plane\ version:\ $ISTIOCTL_VERSION ]]; then
+    dco::_info "Istio is configured"
+  else
+    dco::_info "Installing istio version $ISTIOCTL_VERSION"
+    $bin install -y -f $operator_manifest
+  fi
+
+  dco::_info "Applying a global STRICT mTLS policy"
+  kubectl apply -f istio/global-strict-mtls.yaml 1> /dev/null
+
+  dco::_info "Adding default namespace to service mesh"
+  kubectl label namespaces default istio-injection=enabled --overwrite 1> /dev/null
+}
+
 function dco::display_usage() {
   echo
   echo "Helper script that automates parts of the DCO developer workflow."
@@ -130,11 +164,12 @@ function dco::display_usage() {
   echo "Usage: $(basename "$0") COMMAND"
   echo
   echo "Commands:"
-  echo "  create    Creates Minikube instance configured for DCO development"
-  echo "  build     Build image locally and load it into Minikube"
-  echo "  deploy    Deploy Helm chart into Minikube using latest "
-  echo "  teardown  Destroy Minikube instance"
-  echo "  help      Display usage"
+  echo "  create   Creates Minikube instance configured for DCO development"
+  echo "  istio    Deploy Istio service mesh into Minikube"
+  echo "  build    Build image locally and load it into Minikube"
+  echo "  deploy   Deploy Helm chart into Minikube using latest "
+  echo "  teardown Destroy Minikube instance"
+  echo "  help     Display usage"
 
   exit 1
 }
@@ -145,6 +180,9 @@ function dco::main() {
   case $command in
     create)
       dco::minikube_setup
+      ;;
+    istio)
+      dco::install_istio
       ;;
     build)
       dco::docker_build


### PR DESCRIPTION
Maybe we'll make this the default setup in the future but, at least for now, this gives you another useful command for setting up a development environment.