### PR TITLE
Fix Spark/Istio ports

### DIFF
--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -79,6 +79,11 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 					TargetPort: intstr.FromString("http"),
 					Protocol:   corev1.ProtocolTCP,
 				},
+				{
+					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverBlockManagerPortName),
+					Port:     sc.Spec.Driver.DriverBlockManagerPort,
+					Protocol: corev1.ProtocolTCP,
+				},
 			},
 		},
 	}

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -63,7 +63,6 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 			ClusterIP: corev1.ClusterIPNone,
 			Selector:  SelectorLabels(sc),
 			Ports: []corev1.ServicePort{
-				// TODO enable these ports for Istio support
 				{
 					Name:       "tcp-cluster",
 					Port:       sc.Spec.ClusterPort,

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -1,6 +1,8 @@
 package spark
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -14,7 +16,7 @@ import (
 func NewMasterService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 	ports := []corev1.ServicePort{
 		{
-			Name: "cluster",
+			Name: "tcp-cluster",
 			Port: sc.Spec.ClusterPort,
 			TargetPort: intstr.IntOrString{
 				Type:   intstr.String,
@@ -63,7 +65,7 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 			Ports: []corev1.ServicePort{
 				// TODO enable these ports for Istio support
 				{
-					Name:       "cluster",
+					Name:       "tcp-cluster",
 					Port:       sc.Spec.ClusterPort,
 					TargetPort: intstr.FromString("cluster"),
 				},
@@ -99,19 +101,18 @@ func NewSparkDriverService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 			Selector:  map[string]string{"app.kubernetes.io/instance": sc.Spec.Driver.ExecutionName},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       sc.Spec.Driver.DriverUIPortName,
+					Name:       fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverUIPortName),
 					Port:       sc.Spec.Driver.DriverUIPort,
 					Protocol:   corev1.ProtocolTCP,
 					TargetPort: targetPort,
 				},
-				// TODO enable these ports for Istio support
 				{
-					Name:     sc.Spec.Driver.DriverPortName,
+					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverPortName),
 					Port:     sc.Spec.Driver.DriverPort,
 					Protocol: corev1.ProtocolTCP,
 				},
 				{
-					Name:     sc.Spec.Driver.DriverBlockManagerPortName,
+					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverBlockManagerPortName),
 					Port:     sc.Spec.Driver.DriverBlockManagerPort,
 					Protocol: corev1.ProtocolTCP,
 				},

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -53,8 +53,6 @@ func NewMasterService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 
 // NewHeadlessService creates a headless service that points to worker nodes
 func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
-	targetPort := intstr.FromInt(int(sc.Spec.Driver.DriverUIPort))
-
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      HeadlessServiceName(sc.Name),
@@ -80,17 +78,6 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 					Port:       sc.Spec.TCPWorkerWebPort,
 					TargetPort: intstr.FromString("http"),
 					Protocol:   corev1.ProtocolTCP,
-				},
-				{
-					Name:       fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverUIPortName),
-					Port:       sc.Spec.Driver.DriverUIPort,
-					Protocol:   corev1.ProtocolTCP,
-					TargetPort: targetPort,
-				},
-				{
-					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverPortName),
-					Port:     sc.Spec.Driver.DriverPort,
-					Protocol: corev1.ProtocolTCP,
 				},
 				{
 					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverBlockManagerPortName),

--- a/pkg/resources/spark/service.go
+++ b/pkg/resources/spark/service.go
@@ -53,6 +53,8 @@ func NewMasterService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 
 // NewHeadlessService creates a headless service that points to worker nodes
 func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
+	targetPort := intstr.FromInt(int(sc.Spec.Driver.DriverUIPort))
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      HeadlessServiceName(sc.Name),
@@ -78,6 +80,17 @@ func NewHeadlessService(sc *dcv1alpha1.SparkCluster) *corev1.Service {
 					Port:       sc.Spec.TCPWorkerWebPort,
 					TargetPort: intstr.FromString("http"),
 					Protocol:   corev1.ProtocolTCP,
+				},
+				{
+					Name:       fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverUIPortName),
+					Port:       sc.Spec.Driver.DriverUIPort,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: targetPort,
+				},
+				{
+					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverPortName),
+					Port:     sc.Spec.Driver.DriverPort,
+					Protocol: corev1.ProtocolTCP,
 				},
 				{
 					Name:     fmt.Sprintf("tcp-%s", sc.Spec.Driver.DriverBlockManagerPortName),

--- a/pkg/resources/spark/service_test.go
+++ b/pkg/resources/spark/service_test.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const SparkBlockManagerPortName = "spark-block-manager-port"
+
 func TestNewMasterService(t *testing.T) {
 	rc := sparkClusterFixture()
 	svc := NewMasterService(rc)
@@ -63,6 +65,8 @@ func TestNewMasterService(t *testing.T) {
 func TestNewHeadlessService(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.TCPMasterWebPort = 8080
+	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
+	rc.Spec.Driver.DriverBlockManagerPort = 4042
 	svc := NewHeadlessService(rc)
 
 	expected := &corev1.Service{
@@ -101,6 +105,11 @@ func TestNewHeadlessService(t *testing.T) {
 					TargetPort: intstr.FromString("http"),
 					Protocol:   corev1.ProtocolTCP,
 				},
+				{
+					Name:     "tcp-spark-block-manager-port",
+					Port:     4042,
+					Protocol: corev1.ProtocolTCP,
+				},
 			},
 		},
 	}
@@ -118,7 +127,7 @@ func TestNewSparkDriverService(t *testing.T) {
 	rc.Spec.Driver.DriverPort = 4041
 	rc.Spec.Driver.DriverPortName = "spark-driver-port"
 	rc.Spec.Driver.DriverBlockManagerPort = 4042
-	rc.Spec.Driver.DriverBlockManagerPortName = "spark-block-manager-port"
+	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
 
 	svc := NewSparkDriverService(rc)
 

--- a/pkg/resources/spark/service_test.go
+++ b/pkg/resources/spark/service_test.go
@@ -30,7 +30,7 @@ func TestNewMasterService(t *testing.T) {
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "cluster",
+					Name:       "tcp-cluster",
 					Port:       7077,
 					TargetPort: intstr.FromString("cluster"),
 				},
@@ -86,7 +86,7 @@ func TestNewHeadlessService(t *testing.T) {
 			Ports: []corev1.ServicePort{
 				// these ports are exposed for Istio support
 				{
-					Name:       "cluster",
+					Name:       "tcp-cluster",
 					Port:       7077,
 					TargetPort: intstr.FromString("cluster"),
 				},
@@ -141,18 +141,18 @@ func TestNewSparkDriverService(t *testing.T) {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:       "spark-ui-port",
+					Name:       "tcp-spark-ui-port",
 					Port:       4040,
 					TargetPort: intstr.FromInt(4040),
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
-					Name:     "spark-driver-port",
+					Name:     "tcp-spark-driver-port",
 					Port:     4041,
 					Protocol: corev1.ProtocolTCP,
 				},
 				{
-					Name:     "spark-block-manager-port",
+					Name:     "tcp-spark-block-manager-port",
 					Port:     4042,
 					Protocol: corev1.ProtocolTCP,
 				},

--- a/pkg/resources/spark/service_test.go
+++ b/pkg/resources/spark/service_test.go
@@ -11,7 +11,14 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const SparkBlockManagerPortName = "spark-block-manager-port"
+const (
+	DriverUIPort              = 4040
+	DriverUIPortName          = "spark-ui-port"
+	DriverPort                = 4041
+	DriverPortName            = "spark-driver-port"
+	BlockManagerPort          = 4042
+	SparkBlockManagerPortName = "spark-block-manager-port"
+)
 
 func TestNewMasterService(t *testing.T) {
 	rc := sparkClusterFixture()
@@ -65,8 +72,12 @@ func TestNewMasterService(t *testing.T) {
 func TestNewHeadlessService(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.TCPMasterWebPort = 8080
+	rc.Spec.Driver.DriverUIPort = DriverUIPort
+	rc.Spec.Driver.DriverUIPortName = DriverUIPortName
+	rc.Spec.Driver.DriverPort = DriverPort
+	rc.Spec.Driver.DriverPortName = DriverPortName
+	rc.Spec.Driver.DriverBlockManagerPort = BlockManagerPort
 	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
-	rc.Spec.Driver.DriverBlockManagerPort = 4042
 	svc := NewHeadlessService(rc)
 
 	expected := &corev1.Service{
@@ -106,6 +117,17 @@ func TestNewHeadlessService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
+					Name:       "tcp-spark-ui-port",
+					Port:       4040,
+					TargetPort: intstr.FromInt(4040),
+					Protocol:   corev1.ProtocolTCP,
+				},
+				{
+					Name:     "tcp-spark-driver-port",
+					Port:     4041,
+					Protocol: corev1.ProtocolTCP,
+				},
+				{
 					Name:     "tcp-spark-block-manager-port",
 					Port:     4042,
 					Protocol: corev1.ProtocolTCP,
@@ -122,11 +144,11 @@ func TestNewSparkDriverService(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.Driver.SparkClusterName = clusterName
 	rc.Spec.Driver.ExecutionName = clusterName
-	rc.Spec.Driver.DriverUIPort = 4040
-	rc.Spec.Driver.DriverUIPortName = "spark-ui-port"
-	rc.Spec.Driver.DriverPort = 4041
-	rc.Spec.Driver.DriverPortName = "spark-driver-port"
-	rc.Spec.Driver.DriverBlockManagerPort = 4042
+	rc.Spec.Driver.DriverUIPort = DriverUIPort
+	rc.Spec.Driver.DriverUIPortName = DriverUIPortName
+	rc.Spec.Driver.DriverPort = DriverPort
+	rc.Spec.Driver.DriverPortName = DriverPortName
+	rc.Spec.Driver.DriverBlockManagerPort = BlockManagerPort
 	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
 
 	svc := NewSparkDriverService(rc)

--- a/pkg/resources/spark/service_test.go
+++ b/pkg/resources/spark/service_test.go
@@ -11,14 +11,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const (
-	DriverUIPort              = 4040
-	DriverUIPortName          = "spark-ui-port"
-	DriverPort                = 4041
-	DriverPortName            = "spark-driver-port"
-	BlockManagerPort          = 4042
-	SparkBlockManagerPortName = "spark-block-manager-port"
-)
+const SparkBlockManagerPortName = "spark-block-manager-port"
 
 func TestNewMasterService(t *testing.T) {
 	rc := sparkClusterFixture()
@@ -72,12 +65,8 @@ func TestNewMasterService(t *testing.T) {
 func TestNewHeadlessService(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.TCPMasterWebPort = 8080
-	rc.Spec.Driver.DriverUIPort = DriverUIPort
-	rc.Spec.Driver.DriverUIPortName = DriverUIPortName
-	rc.Spec.Driver.DriverPort = DriverPort
-	rc.Spec.Driver.DriverPortName = DriverPortName
-	rc.Spec.Driver.DriverBlockManagerPort = BlockManagerPort
 	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
+	rc.Spec.Driver.DriverBlockManagerPort = 4042
 	svc := NewHeadlessService(rc)
 
 	expected := &corev1.Service{
@@ -117,17 +106,6 @@ func TestNewHeadlessService(t *testing.T) {
 					Protocol:   corev1.ProtocolTCP,
 				},
 				{
-					Name:       "tcp-spark-ui-port",
-					Port:       4040,
-					TargetPort: intstr.FromInt(4040),
-					Protocol:   corev1.ProtocolTCP,
-				},
-				{
-					Name:     "tcp-spark-driver-port",
-					Port:     4041,
-					Protocol: corev1.ProtocolTCP,
-				},
-				{
 					Name:     "tcp-spark-block-manager-port",
 					Port:     4042,
 					Protocol: corev1.ProtocolTCP,
@@ -144,11 +122,11 @@ func TestNewSparkDriverService(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.Driver.SparkClusterName = clusterName
 	rc.Spec.Driver.ExecutionName = clusterName
-	rc.Spec.Driver.DriverUIPort = DriverUIPort
-	rc.Spec.Driver.DriverUIPortName = DriverUIPortName
-	rc.Spec.Driver.DriverPort = DriverPort
-	rc.Spec.Driver.DriverPortName = DriverPortName
-	rc.Spec.Driver.DriverBlockManagerPort = BlockManagerPort
+	rc.Spec.Driver.DriverUIPort = 4040
+	rc.Spec.Driver.DriverUIPortName = "spark-ui-port"
+	rc.Spec.Driver.DriverPort = 4041
+	rc.Spec.Driver.DriverPortName = "spark-driver-port"
+	rc.Spec.Driver.DriverBlockManagerPort = 4042
 	rc.Spec.Driver.DriverBlockManagerPortName = SparkBlockManagerPortName
 
 	svc := NewSparkDriverService(rc)

--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -123,6 +123,7 @@ function dco::helm_install() {
     --set image.repository="$IMAGE_NAME" \
     --set image.tag="$latest_tag" \
     --set config.logDevelopmentMode=true
+    --set istio.enabled=true
 }
 
 dco::install_istio() {

--- a/scripts/development.sh
+++ b/scripts/development.sh
@@ -123,7 +123,6 @@ function dco::helm_install() {
     --set image.repository="$IMAGE_NAME" \
     --set image.tag="$latest_tag" \
     --set config.logDevelopmentMode=true
-    --set istio.enabled=true
 }
 
 dco::install_istio() {


### PR DESCRIPTION
Spark workers need to have the `block-manager` port exposed. 

This PR prefixes all Spark service ports with `tcp-` to force Istio to use `TCP`, as well as adds the `block-manager` port to the Spark worker service.

This PR was successfully tested on a deployment using the following script:
```
def install_pyspark():
    import importlib.util
    if importlib.util.find_spec('pyspark') is None:
        import subprocess
        print("Installing PySpark...")
        subprocess.run(['pip', 'install', 'pyspark==3.1.1'])
        print("PySpark successfully installed!")

install_pyspark()

import pyspark
sc = pyspark.SparkContext()
words = ['cat', 'elephant', 'rat', 'rat', 'cat']
wordRdd = sc.parallelize(words, 4)
pairRdd = wordRdd.map(lambda word: (word, 1))
counts = pairRdd.reduceByKey(lambda a, b: a + b)
print(counts.collect())
```