### PR TITLE
Fixes Dask network policy ingress rules

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ coverage:
     project:
       default:
         target: 75%
-        threshold: 5%
+        threshold: 10%
     patch: off
 ignore:
   - "api/**/zz_generated.deepcopy.go"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -91,3 +91,5 @@ issues:
     - source: "^//\\s*\\+kubebuilder:.+"
       linters:
         - lll
+  exclude:
+    - Using the variable on range scope `tc` in function literal

--- a/api/v1alpha1/common.go
+++ b/api/v1alpha1/common.go
@@ -96,6 +96,7 @@ type WorkloadConfig struct {
 }
 
 type ClusterStatusConfig struct {
+	Image          string   `json:"image,omitempty"`
 	Nodes          []string `json:"nodes,omitempty"`
 	WorkerReplicas int32    `json:"workerReplicas,omitempty"`
 	WorkerSelector string   `json:"workerSelector,omitempty"`

--- a/api/v1alpha1/daskcluster_types.go
+++ b/api/v1alpha1/daskcluster_types.go
@@ -32,6 +32,11 @@ type DaskClusterStatus struct {
 //+kubebuilder:resource:shortName=dask
 //+kubebuilder:subresource:status
 //+kubebuilder:subresource:scale:specpath=.spec.worker.replicas,statuspath=.status.workerReplicas,selectorpath=.status.workerSelector
+//+kubebuilder:printcolumn:name="Workers",type=integer,JSONPath=".spec.worker.replicas"
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=".metadata.creationTimestamp"
+//+kubebuilder:printcolumn:name="Image",type=string,JSONPath=".status.image"
+//+kubebuilder:printcolumn:name="Network Policy",type=boolean,JSONPath=".spec.networkPolicy.enabled",priority=10
+//+kubebuilder:printcolumn:name="Pods",type=string,JSONPath=".status.nodes",priority=10
 
 // DaskCluster is the Schema for the daskclusters API.
 type DaskCluster struct {

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -30,7 +30,7 @@ var (
 
 	daskDefaultImage = &OCIImageDefinition{
 		Repository: "daskdev/dask",
-		Tag:        "2021.6.1",
+		Tag:        "2021.7.2",
 		PullPolicy: corev1.PullIfNotPresent,
 	}
 

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -18,8 +18,8 @@ var (
 	daskDefaultWorkerPort    int32 = 3000
 	daskDefaultNannyPort     int32 = 3001
 
-	daskDefaultWorkerReplicas      = pointer.Int32Ptr(1)
-	daskDefaultEnableNetworkPolicy = pointer.BoolPtr(true)
+	daskDefaultWorkerReplicas      = pointer.Int32(1)
+	daskDefaultEnableNetworkPolicy = pointer.Bool(true)
 	daskDefaultNetworkPolicyLabels = map[string]string{
 		"dask-client": "true",
 	}
@@ -76,7 +76,7 @@ func (dc *DaskCluster) Default() {
 		spec.PodSecurityContext = daskDefaultPodSecurityContext
 	}
 	if spec.NetworkPolicy.Enabled == nil {
-		log.Info("Setting enable network policy flag", "value", pointer.BoolPtr(true))
+		log.Info("Setting enable network policy flag", "value", pointer.Bool(true))
 		spec.NetworkPolicy.Enabled = daskDefaultEnableNetworkPolicy
 	}
 	if spec.NetworkPolicy.ClientLabels == nil {

--- a/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.v1beta1.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.v1beta1.yaml
@@ -8,6 +8,24 @@ metadata:
   creationTimestamp: null
   name: daskclusters.distributed-compute.dominodatalab.com
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.worker.replicas
+    name: Workers
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.image
+    name: Image
+    type: string
+  - JSONPath: .spec.networkPolicy.enabled
+    name: Network Policy
+    priority: 10
+    type: boolean
+  - JSONPath: .status.nodes
+    name: Pods
+    priority: 10
+    type: string
   group: distributed-compute.dominodatalab.com
   names:
     kind: DaskCluster
@@ -7804,6 +7822,8 @@ spec:
         status:
           description: DaskClusterStatus defines the observed state of DaskCluster
           properties:
+            image:
+              type: string
             nodes:
               items:
                 type: string

--- a/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
@@ -18,7 +18,25 @@ spec:
     singular: daskcluster
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.worker.replicas
+      name: Workers
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.image
+      name: Image
+      type: string
+    - jsonPath: .spec.networkPolicy.enabled
+      name: Network Policy
+      priority: 10
+      type: boolean
+    - jsonPath: .status.nodes
+      name: Pods
+      priority: 10
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: DaskCluster is the Schema for the daskclusters API.
@@ -7952,6 +7970,8 @@ spec:
           status:
             description: DaskClusterStatus defines the observed state of DaskCluster
             properties:
+              image:
+                type: string
               nodes:
                 items:
                   type: string

--- a/pkg/cluster/dask/clusterstatusupdate.go
+++ b/pkg/cluster/dask/clusterstatusupdate.go
@@ -39,3 +39,7 @@ func (c *clusterStatusUpdateDS) StatefulSet() *appsv1.StatefulSet {
 func (c *clusterStatusUpdateDS) ClusterStatusConfig() *dcv1alpha1.ClusterStatusConfig {
 	return &c.dc.Status.ClusterStatusConfig
 }
+
+func (c *clusterStatusUpdateDS) Image() *dcv1alpha1.OCIImageDefinition {
+	return c.dc.Spec.Image
+}

--- a/pkg/cluster/dask/dask_test.go
+++ b/pkg/cluster/dask/dask_test.go
@@ -27,6 +27,7 @@ func testDaskCluster() *dcv1alpha1.DaskCluster {
 						"test-ui-client": "true",
 					},
 				},
+				PodSecurityPolicy: "privileged",
 			},
 			Scheduler:     dcv1alpha1.WorkloadConfig{},
 			Worker:        dcv1alpha1.DaskClusterWorker{},

--- a/pkg/cluster/dask/dask_test.go
+++ b/pkg/cluster/dask/dask_test.go
@@ -1,0 +1,39 @@
+package dask
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
+)
+
+func testDaskCluster() *dcv1alpha1.DaskCluster {
+	return &dcv1alpha1.DaskCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "ns",
+		},
+		Spec: dcv1alpha1.DaskClusterSpec{
+			ClusterConfig: dcv1alpha1.ClusterConfig{
+				Image: &dcv1alpha1.OCIImageDefinition{
+					Registry:   "",
+					Repository: "daskdev/dask",
+					Tag:        "test-tag",
+				},
+				NetworkPolicy: dcv1alpha1.NetworkPolicyConfig{
+					ClientLabels: map[string]string{
+						"test-client": "true",
+					},
+					DashboardLabels: map[string]string{
+						"test-ui-client": "true",
+					},
+				},
+			},
+			Scheduler:     dcv1alpha1.WorkloadConfig{},
+			Worker:        dcv1alpha1.DaskClusterWorker{},
+			SchedulerPort: 8786,
+			DashboardPort: 8787,
+			WorkerPort:    3000,
+			NannyPort:     3001,
+		},
+	}
+}

--- a/pkg/cluster/dask/networkpolicy_test.go
+++ b/pkg/cluster/dask/networkpolicy_test.go
@@ -1,0 +1,206 @@
+package dask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestNetworkPolicyDataSource(t *testing.T) {
+	dc := testDaskCluster()
+	tcpProto := corev1.ProtocolTCP
+	dashboardPort := intstr.FromInt(8787)
+
+	t.Run("scheduler", func(t *testing.T) {
+		ds := networkPolicyDS{dc: dc, comp: ComponentScheduler}
+		schedulerPort := intstr.FromInt(8786)
+
+		actual := ds.NetworkPolicy()
+		expected := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dask-scheduler",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/component":  "scheduler",
+					"app.kubernetes.io/instance":   "test",
+					"app.kubernetes.io/managed-by": "distributed-compute-operator",
+					"app.kubernetes.io/name":       "dask",
+					"app.kubernetes.io/version":    "test-tag",
+				},
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/component": "scheduler",
+						"app.kubernetes.io/instance":  "test",
+						"app.kubernetes.io/name":      "dask",
+					},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &tcpProto,
+								Port:     &schedulerPort,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"test-client": "true",
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/component": "worker",
+										"app.kubernetes.io/instance":  "test",
+										"app.kubernetes.io/name":      "dask",
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &tcpProto,
+								Port:     &dashboardPort,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"test-ui-client": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+				},
+			},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("worker", func(t *testing.T) {
+		ds := networkPolicyDS{dc: dc, comp: ComponentWorker}
+		workerPort := intstr.FromInt(3000)
+		nannyPort := intstr.FromInt(3001)
+
+		actual := ds.NetworkPolicy()
+		expected := &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dask-worker",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/component":  "worker",
+					"app.kubernetes.io/instance":   "test",
+					"app.kubernetes.io/managed-by": "distributed-compute-operator",
+					"app.kubernetes.io/name":       "dask",
+					"app.kubernetes.io/version":    "test-tag",
+				},
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app.kubernetes.io/component": "worker",
+						"app.kubernetes.io/instance":  "test",
+						"app.kubernetes.io/name":      "dask",
+					},
+				},
+				Ingress: []networkingv1.NetworkPolicyIngressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &tcpProto,
+								Port:     &workerPort,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/component": "scheduler",
+										"app.kubernetes.io/instance":  "test",
+										"app.kubernetes.io/name":      "dask",
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/component": "worker",
+										"app.kubernetes.io/instance":  "test",
+										"app.kubernetes.io/name":      "dask",
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &tcpProto,
+								Port:     &nannyPort,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/component": "scheduler",
+										"app.kubernetes.io/instance":  "test",
+										"app.kubernetes.io/name":      "dask",
+									},
+								},
+							},
+						},
+					},
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Protocol: &tcpProto,
+								Port:     &dashboardPort,
+							},
+						},
+						From: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/component": "scheduler",
+										"app.kubernetes.io/instance":  "test",
+										"app.kubernetes.io/name":      "dask",
+									},
+								},
+							},
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"test-ui-client": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeIngress,
+				},
+			},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/pkg/cluster/dask/rbac_test.go
+++ b/pkg/cluster/dask/rbac_test.go
@@ -1,0 +1,86 @@
+package dask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestPspDS_Role(t *testing.T) {
+	dc := testDaskCluster()
+	ds := pspDS{dc: dc}
+
+	actual := ds.Role()
+	expected := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dask",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "test",
+				"app.kubernetes.io/managed-by": "distributed-compute-operator",
+				"app.kubernetes.io/name":       "dask",
+				"app.kubernetes.io/version":    "test-tag",
+			},
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups:     []string{"policy"},
+				Resources:     []string{"podsecuritypolicies"},
+				Verbs:         []string{"use"},
+				ResourceNames: []string{"privileged"},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestPspDS_RoleBinding(t *testing.T) {
+	dc := testDaskCluster()
+	ds := pspDS{dc: dc}
+
+	actual := ds.RoleBinding()
+	expected := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dask",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "test",
+				"app.kubernetes.io/managed-by": "distributed-compute-operator",
+				"app.kubernetes.io/name":       "dask",
+				"app.kubernetes.io/version":    "test-tag",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     "test-dask",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "test-dask",
+				Namespace: "ns",
+			},
+		},
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestPspDS_Delete(t *testing.T) {
+	dc := testDaskCluster()
+	ds := pspDS{dc: dc}
+
+	t.Run("provided_name", func(t *testing.T) {
+		dc.Spec.PodSecurityPolicy = "restricted"
+		assert.False(t, ds.Delete())
+	})
+
+	t.Run("empty_name", func(t *testing.T) {
+		dc.Spec.PodSecurityPolicy = ""
+		assert.True(t, ds.Delete())
+	})
+}

--- a/pkg/cluster/dask/service_test.go
+++ b/pkg/cluster/dask/service_test.go
@@ -1,0 +1,101 @@
+package dask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func TestServiceDataSource_Service(t *testing.T) {
+	dc := testDaskCluster()
+
+	t.Run("scheduler", func(t *testing.T) {
+		ds := serviceDS{dc: dc, comp: ComponentScheduler}
+
+		actual := ds.Service()
+		expected := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dask-scheduler",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/component":  "scheduler",
+					"app.kubernetes.io/instance":   "test",
+					"app.kubernetes.io/managed-by": "distributed-compute-operator",
+					"app.kubernetes.io/name":       "dask",
+					"app.kubernetes.io/version":    "test-tag",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: corev1.ClusterIPNone,
+				Selector: map[string]string{
+					"app.kubernetes.io/component": "scheduler",
+					"app.kubernetes.io/instance":  "test",
+					"app.kubernetes.io/name":      "dask",
+				},
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "tcp-serve",
+						Port:       8786,
+						TargetPort: intstr.FromString("serve"),
+					},
+					{
+						Name:       "tcp-dashboard",
+						Port:       8787,
+						TargetPort: intstr.FromString("dashboard"),
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("worker", func(t *testing.T) {
+		ds := serviceDS{dc: dc, comp: ComponentWorker}
+
+		actual := ds.Service()
+		expected := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-dask-worker",
+				Namespace: "ns",
+				Labels: map[string]string{
+					"app.kubernetes.io/component":  "worker",
+					"app.kubernetes.io/instance":   "test",
+					"app.kubernetes.io/managed-by": "distributed-compute-operator",
+					"app.kubernetes.io/name":       "dask",
+					"app.kubernetes.io/version":    "test-tag",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				ClusterIP: corev1.ClusterIPNone,
+				Selector: map[string]string{
+					"app.kubernetes.io/component": "worker",
+					"app.kubernetes.io/instance":  "test",
+					"app.kubernetes.io/name":      "dask",
+				},
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "tcp-worker",
+						Port:       3000,
+						TargetPort: intstr.FromString("worker"),
+					},
+					{
+						Name:       "tcp-nanny",
+						Port:       3001,
+						TargetPort: intstr.FromString("nanny"),
+					},
+					{
+						Name:       "tcp-dashboard",
+						Port:       8787,
+						TargetPort: intstr.FromString("dashboard"),
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/pkg/cluster/dask/serviceaccount.go
+++ b/pkg/cluster/dask/serviceaccount.go
@@ -31,7 +31,7 @@ func (s *serviceAccountDS) ServiceAccount() *corev1.ServiceAccount {
 			Namespace: s.dc.Namespace,
 			Labels:    meta.StandardLabels(s.dc),
 		},
-		AutomountServiceAccountToken: pointer.BoolPtr(s.dc.Spec.ServiceAccount.AutomountServiceAccountToken),
+		AutomountServiceAccountToken: pointer.Bool(s.dc.Spec.ServiceAccount.AutomountServiceAccountToken),
 	}
 }
 

--- a/pkg/cluster/dask/serviceaccount_test.go
+++ b/pkg/cluster/dask/serviceaccount_test.go
@@ -1,0 +1,53 @@
+package dask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestServiceAccountDS_ServiceAccount(t *testing.T) {
+	dc := testDaskCluster()
+	ds := serviceAccountDS{dc: dc}
+
+	actual := ds.ServiceAccount()
+	expected := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dask",
+			Namespace: "ns",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "test",
+				"app.kubernetes.io/managed-by": "distributed-compute-operator",
+				"app.kubernetes.io/name":       "dask",
+				"app.kubernetes.io/version":    "test-tag",
+			},
+		},
+		AutomountServiceAccountToken: pointer.Bool(false),
+	}
+
+	require.Equal(t, expected, actual)
+
+	dc.Spec.ServiceAccount.AutomountServiceAccountToken = true
+	actual = ds.ServiceAccount()
+
+	assert.Equal(t, actual.AutomountServiceAccountToken, pointer.Bool(true))
+}
+
+func TestServiceAccountDS_Delete(t *testing.T) {
+	dc := testDaskCluster()
+	ds := serviceAccountDS{dc: dc}
+
+	t.Run("empty_name", func(t *testing.T) {
+		dc.Spec.ServiceAccount.Name = ""
+		assert.False(t, ds.Delete())
+	})
+
+	t.Run("provided_name", func(t *testing.T) {
+		dc.Spec.ServiceAccount.Name = "other"
+		assert.True(t, ds.Delete())
+	})
+}

--- a/pkg/controller/components/clusterstatusupdate.go
+++ b/pkg/controller/components/clusterstatusupdate.go
@@ -13,12 +13,14 @@ import (
 
 	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
 	"github.com/dominodatalab/distributed-compute-operator/pkg/controller/core"
+	"github.com/dominodatalab/distributed-compute-operator/pkg/util"
 )
 
 type ClusterStatusUpdateDataSource interface {
 	ListOpts() []client.ListOption
 	StatefulSet() *appsv1.StatefulSet
 	ClusterStatusConfig() *dcv1alpha1.ClusterStatusConfig
+	Image() *dcv1alpha1.OCIImageDefinition
 }
 
 type ClusterStatusUpdateDataSourceFactory func(client.Object) ClusterStatusUpdateDataSource
@@ -36,6 +38,16 @@ func (c *clusterStatusUpdateComponent) Reconcile(ctx *core.Context) (ctrl.Result
 
 	ds := c.factory(ctx.Object)
 	csc := ds.ClusterStatusConfig()
+
+	// store canonical image reference
+	image, err := util.ParseImageDefinition(ds.Image())
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("cannot build cluster image: %w", err)
+	}
+	if csc.Image != image {
+		csc.Image = image
+		modified = true
+	}
 
 	// modify node list field
 	podList := &corev1.PodList{}
@@ -57,7 +69,7 @@ func (c *clusterStatusUpdateComponent) Reconcile(ctx *core.Context) (ctrl.Result
 
 	// modify scale subresource fields
 	sts := ds.StatefulSet()
-	err := ctx.Client.Get(ctx, client.ObjectKeyFromObject(sts), sts)
+	err = ctx.Client.Get(ctx, client.ObjectKeyFromObject(sts), sts)
 	if client.IgnoreNotFound(err) != nil {
 		return ctrl.Result{}, err
 	}
@@ -76,6 +88,7 @@ func (c *clusterStatusUpdateComponent) Reconcile(ctx *core.Context) (ctrl.Result
 		modified = true
 	}
 
+	// only update when fields have changed
 	if modified {
 		err = ctx.Client.Status().Update(ctx, ctx.Object)
 	}


### PR DESCRIPTION
Testing was initially performed with a single worker and missed the requirement for worker-to-worker communication on port 3000. Also opens open up worker dashboard port (8787) to client-labeled pods since the _scheduler-delegated worker dashboards_ does not work as originally expected.

### Extra

- Builds and adds canonical image url to status
- Adds extra printer columns to `kubectl get dask`