### PR TITLE
Allows dco to process CRs in other namespaces

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,7 +10,6 @@ import (
 )
 
 var (
-	namespace            string
 	probeAddr            string
 	metricsAddr          string
 	webhookPort          int
@@ -24,7 +23,6 @@ var startCmd = &cobra.Command{
 	Short: "Start the controller manager",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := &manager.Config{
-			Namespace:            namespace,
 			MetricsAddr:          metricsAddr,
 			HealthProbeAddr:      probeAddr,
 			WebhookServerPort:    webhookPort,
@@ -44,7 +42,6 @@ func init() {
 	zapOpts.BindFlags(fs)
 
 	startCmd.Flags().AddGoFlagSet(fs)
-	startCmd.Flags().StringVar(&namespace, "namespace", "default", "Reconcile clusters resources in this namespace")
 	startCmd.Flags().IntVar(&webhookPort, "webhook-server-port", 9443, "Webhook server will bind to this port")
 	startCmd.Flags().StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"Metrics endpoint will bind to this address")

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	namespaces           []string
 	probeAddr            string
 	metricsAddr          string
 	webhookPort          int
@@ -23,6 +24,7 @@ var startCmd = &cobra.Command{
 	Short: "Start the controller manager",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg := &manager.Config{
+			Namespaces:           namespaces,
 			MetricsAddr:          metricsAddr,
 			HealthProbeAddr:      probeAddr,
 			WebhookServerPort:    webhookPort,
@@ -42,6 +44,7 @@ func init() {
 	zapOpts.BindFlags(fs)
 
 	startCmd.Flags().AddGoFlagSet(fs)
+	startCmd.Flags().StringSliceVar(&namespaces, "namespaces", nil, "Only reconcile resources in these namespaces")
 	startCmd.Flags().IntVar(&webhookPort, "webhook-server-port", 9443, "Webhook server will bind to this port")
 	startCmd.Flags().StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"Metrics endpoint will bind to this address")

--- a/deploy/helm/distributed-compute-operator/templates/clusterrole.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/clusterrole.yaml
@@ -6,39 +6,6 @@ metadata:
     {{- include "common.labels.standard" . | nindent 4 }}
 rules:
 - apiGroups:
-  - policy
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-  - list
-  - watch
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "dco.rbac.managerName" . }}.{{ .Release.Namespace }}
-  labels:
-    {{- include "common.labels.standard" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "dco.rbac.managerName" . }}.{{ .Release.Namespace }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "dco.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ include "dco.rbac.managerName" . }}
-  labels:
-    {{- include "common.labels.standard" . | nindent 4 }}
-rules:
-- apiGroups:
   - distributed-compute.dominodatalab.com
   resources:
   - daskclusters
@@ -130,6 +97,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
@@ -151,26 +126,21 @@ rules:
   - list
   - watch
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - envoyfilters
+  - envoyfilters
   verbs:
-    - create
-    - update
-    - delete
-    - list
-    - watch
+  - create
+  - update
+  - list
+  - watch
+{{- if .Values.config.enableLeaderElection }}
 - apiGroups:
-  - ""
+    - ""
   resources:
   - configmaps
   verbs:
   - get
-  - create
-  - update
-  - watch
-  - list
-{{- if .Values.config.enableLeaderElection }}
 - apiGroups:
   - ""
   resources:
@@ -186,18 +156,3 @@ rules:
   - create
   - update
 {{- end }}
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "dco.rbac.managerName" . }}
-  labels:
-    {{- include "common.labels.standard" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "dco.rbac.managerName" . }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "dco.serviceAccountName" . }}

--- a/deploy/helm/distributed-compute-operator/templates/clusterrolebinding.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dco.rbac.managerName" . }}.{{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels.standard" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dco.rbac.managerName" . }}.{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dco.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deploy/helm/distributed-compute-operator/templates/deployment.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/deployment.yaml
@@ -46,6 +46,9 @@ spec:
             - --webhook-server-port={{ .webhookPort }}
             - --metrics-bind-address=:{{ .metricsPort }}
             - --health-probe-bind-address=:{{ .healthProbePort }}
+            {{- with .watchNamespaces }}
+            - --namespaces={{ . | join "," }}
+            {{- end }}
             {{- if .enableLeaderElection }}
             - --leader-elect
             {{- end }}

--- a/deploy/helm/distributed-compute-operator/templates/deployment.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/deployment.yaml
@@ -42,7 +42,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - start
-            - --namespace={{ .Release.Namespace }}
             {{- with .Values.config }}
             - --webhook-server-port={{ .webhookPort }}
             - --metrics-bind-address=:{{ .metricsPort }}

--- a/deploy/helm/distributed-compute-operator/values.yaml
+++ b/deploy/helm/distributed-compute-operator/values.yaml
@@ -11,6 +11,9 @@ installCRDs: true
 
 # Controller manager configuration
 config:
+  # Limit watch to a specific set of namespaces, default is all namespaces.
+  watchNamespaces: []
+
   # Webhook server port
   webhookPort: 9443
   # Prometheus metrics port

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -4,6 +4,7 @@ import "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 // Config options for the controller manager.
 type Config struct {
+	Namespaces           []string
 	MetricsAddr          string
 	HealthProbeAddr      string
 	WebhookServerPort    int

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -4,7 +4,6 @@ import "sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 // Config options for the controller manager.
 type Config struct {
-	Namespace            string
 	MetricsAddr          string
 	HealthProbeAddr      string
 	WebhookServerPort    int

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -35,14 +36,22 @@ type Controllers []func(ctrl.Manager, bool) error
 func Start(cfg *Config) error {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&cfg.ZapOptions)))
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     cfg.MetricsAddr,
 		Port:                   cfg.WebhookServerPort,
 		HealthProbeBindAddress: cfg.HealthProbeAddr,
 		LeaderElection:         cfg.EnableLeaderElection,
 		LeaderElectionID:       leaderElectionID,
-	})
+	}
+	if len(cfg.Namespaces) > 0 {
+		setupLog.Info("Limiting reconciliation watch", "namespaces", cfg.Namespaces)
+		mgrOpts.NewCache = cache.MultiNamespacedCacheBuilder(cfg.Namespaces)
+	} else {
+		setupLog.Info("Watching all namespaces")
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		return err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -42,7 +42,6 @@ func Start(cfg *Config) error {
 		HealthProbeBindAddress: cfg.HealthProbeAddr,
 		LeaderElection:         cfg.EnableLeaderElection,
 		LeaderElectionID:       leaderElectionID,
-		Namespace:              cfg.Namespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This does not require the application to be re-deployed but does allow us the ability the move the DCO into a different namespace. I think that operationally this design makes more sense since DCO is more of a cluster component.