### PR TITLE
allow retries of CRD hooks during helm install

### DIFF
--- a/deploy/helm/distributed-compute-operator/templates/hooks.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/hooks.yaml
@@ -69,7 +69,7 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 0
+  backoffLimit: 3
   template:
     metadata:
       labels:
@@ -118,7 +118,7 @@ metadata:
     "helm.sh/hook": post-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  backoffLimit: 0
+  backoffLimit: 3
   template:
     metadata:
       labels:


### PR DESCRIPTION
There is the chance of a race condition with Istio/CNI and pods on a new
node that, for a Job with a backoffLimit=0, could cause a failure when a
a simple retry would work.