### PR TITLE
reverts change to ray client service dashboard port

### DIFF
--- a/pkg/resources/ray/service.go
+++ b/pkg/resources/ray/service.go
@@ -24,7 +24,7 @@ func NewClientService(rc *dcv1alpha1.RayCluster) *corev1.Service {
 
 	if util.BoolPtrIsTrue(rc.Spec.EnableDashboard) {
 		ports = append(ports, corev1.ServicePort{
-			Name:       "http-dashboard",
+			Name:       "tcp-dashboard",
 			Port:       rc.Spec.DashboardPort,
 			TargetPort: intstr.FromInt(int(rc.Spec.DashboardPort)),
 		})

--- a/pkg/resources/ray/service_test.go
+++ b/pkg/resources/ray/service_test.go
@@ -48,7 +48,7 @@ func TestNewClientService(t *testing.T) {
 		svc := NewClientService(rc)
 
 		expected.Spec.Ports = append(expected.Spec.Ports, corev1.ServicePort{
-			Name:       "http-dashboard",
+			Name:       "tcp-dashboard",
 			Port:       8265,
 			TargetPort: intstr.FromInt(8265),
 		})


### PR DESCRIPTION
the name needs to be prefixed with "tcp-" otherwise Istio will give you
the business.