### PR TITLE
Add delete permission to statefulsets in dco clusterrole

### DIFF
--- a/deploy/helm/distributed-compute-operator/templates/clusterrole.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/clusterrole.yaml
@@ -81,6 +81,7 @@ rules:
   - update
   - list
   - watch
+  - delete
 - apiGroups:
   - autoscaling
   resources:


### PR DESCRIPTION
It looks to me like this is the only missing perm - when I add it, I don't see any errors on mpicluster CR delete. But if we are deleting the service/endpoint then we need to add that too.