### PR TITLE
[DOM-36776] Add imported module to rsyncd.conf

### DIFF
--- a/dockerfiles/rsyncd.conf
+++ b/dockerfiles/rsyncd.conf
@@ -10,3 +10,6 @@ path = /mnt
 
 [repos]
 path = /repos
+
+[imported]
+path = /mnt/imported


### PR DESCRIPTION
Add imported module to rsyncd.conf to sync /mnt/imported

https://dominodatalab.atlassian.net/browse/DOM-36776