### PR TITLE
RM-1305 Update debian OS libs in MPI images

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220210-1721
+FROM quay.io/domino/debian:10.11-20220520-1846
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220210-1721
+FROM quay.io/domino/debian:10.11-20220520-1846
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
### What problem does this PR solve?
* We need to update the base Debian image tag for `*-mpi-*` images to bring in OS lib updates with security fixes from upstream.
    * these images need to be updated as part of the [release OSRP Process](https://dominodatalab.atlassian.net/wiki/spaces/ENG/pages/1938522147/OSRP+Process) going forward and we need this for the currently ongoing 5.1.3 release.
    * More context: [RM-1305](https://dominodatalab.atlassian.net/browse/RM-1305)

### What is the solution?
* Update the base Debian image tag to `quay.io/domino/debian:10.11-20220520-1846`, which includes updated OS libs from upstream Debian's package manager.