### PR TITLE
RM-1130 Updated 2nd order Image for OSRP 5.2.0

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220520-1846
+FROM quay.io/domino/debian:10.11-20220621-1030
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220520-1846
+FROM quay.io/domino/debian:10.11-20220621-1030
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
Link to JIRA: https://dominodatalab.atlassian.net/browse/RM-1130
Updated the 2nd order images for OSRP 5.2.0. Below is the build-images run from where new image tag is copied:
https://app.circleci.com/pipelines/github/cerebrotech/build-images/2205/workflows/1ac63d46-589f-40ca-a47b-dca8c584b607/jobs/166721