### PR TITLE
RM-1491 Updated 2nd order image for OSRP 5.2.1

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220621-1030
+FROM quay.io/domino/debian:10.11-20220724-2015
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220621-1030
+FROM quay.io/domino/debian:10.11-20220724-2015
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
Link to JIRA: https://dominodatalab.atlassian.net/browse/RM-1491
Updated the 2nd order images for OSRP 5.2.1. Below is the build-images run from where the new image tag is copied:
https://app.circleci.com/pipelines/github/cerebrotech/build-images/2276/workflows/19404c9f-a07e-4337-a1f5-ff03a41be00a/jobs/175566?invite=true#step-102-7