### PR TITLE
add the envoyfilter template and defaults that allows setting istio h…

### DIFF
--- a/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
@@ -3,11 +3,10 @@
 {{- $defaultNamespaces := .Values.config.watchNamespaces | default $justRootConfigNamespace }}
 {{- $namespaces := .Values.istio.httpIdleTimeout.namespaces | default $defaultNamespaces }}
 {{- range $namespace := $namespaces }}
----
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: distributed-compute-cluster-envoyfilter
+  name: {{ include "common.names.fullname" . }}-envoyfilter
   namespace: {{ $namespace }}
 spec:
   workloadSelector:
@@ -41,6 +40,5 @@ spec:
         typed_config:
           '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
           idle_timeout: {{ $.Values.istio.httpIdleTimeout.timeout }}
----
 {{- end }}
 {{- end }}

--- a/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
@@ -1,0 +1,46 @@
+{{- if and (.Values.istio.enabled) (.Values.istio.httpIdleTimeout.timeout)  }}
+{{- $justRootConfigNamespace := list .Values.istio.rootConfigNamespace }}
+{{- $defaultNamespaces := .Values.config.watchNamespaces | default $justRootConfigNamespace }}
+{{- $namespaces := .Values.istio.httpIdleTimeout.namespaces | default $defaultNamespaces }}
+{{- range $namespace := $namespaces }}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: distributed-compute-cluster-envoyfilter
+  namespace: {{ $namespace }}
+spec:
+  workloadSelector:
+    labels:
+      app.kubernetes.io/managed-by: distributed-compute-operator
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        name: "envoy.filters.network.http_connection_manager"
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          common_http_protocol_options:
+            idle_timeout: {{ $.Values.istio.httpIdleTimeout.timeout }}
+  - applyTo: NETWORK_FILTER
+    match:
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.tcp_proxy
+    patch:
+      operation: MERGE
+      value:
+        name: envoy.filters.network.tcp_proxy
+        typed_config:
+          '@type': type.googleapis.com/envoy.config.filter.network.tcp_proxy.v2.TcpProxy
+          idle_timeout: {{ $.Values.istio.httpIdleTimeout.timeout }}
+---
+{{- end }}
+{{- end }}

--- a/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
+++ b/deploy/helm/distributed-compute-operator/templates/http-timeout-envoyfilter.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.istio.enabled) (.Values.istio.httpIdleTimeout.timeout)  }}
+{{- $commonFullname := include "common.names.fullname" . }}
 {{- $justRootConfigNamespace := list .Values.istio.rootConfigNamespace }}
 {{- $defaultNamespaces := .Values.config.watchNamespaces | default $justRootConfigNamespace }}
 {{- $namespaces := .Values.istio.httpIdleTimeout.namespaces | default $defaultNamespaces }}
@@ -6,7 +7,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: {{ include "common.names.fullname" . }}-envoyfilter
+  name: {{ $commonFullname }}-envoyfilter
   namespace: {{ $namespace }}
 spec:
   workloadSelector:

--- a/deploy/helm/distributed-compute-operator/values.yaml
+++ b/deploy/helm/distributed-compute-operator/values.yaml
@@ -38,6 +38,18 @@ istio:
   # Elevate pod execution permissions so that Istio's init container can modify
   # network settings when CNI plugin is NOT installed
   cniPluginInstalled: true
+  # namespace for istio mesh-level settings
+  rootConfigNamespace: istio-config
+  # set the HTTP connection idle timeout for pods managed by the distributed-compute-operator
+  httpIdleTimeout:
+    # the timeout to set. Leave empty for istio default.
+    timeout: ""
+    # If timeout and namespaces are set, sets the timeout only in given namespaces.
+    # If timeout is set but namespaces is empty:
+    #   - if config.watchNamespaces is empty, then timeout is set across the whole istio mesh
+    #   - else timeout is set for namespaces in config.watchNamespaces
+    # If any namespaces in the istio mesh are unaffected by this setting, they get istio default.
+    namespaces: []
 
 podSecurityPolicy:
   # Create custom PSP for operator


### PR DESCRIPTION
**Problem**
Some workloads that use `distributed-compute-operator` (DCO) have an HTTP communication pattern that leaves HTTP connections open but unused for longer than an hour. But, Istio has a default HTTP idle timeout of one hour, after which it closes such connections, which can cause unrecoverable errors in the workload. One example is using PyTorch with Ray: Each worker opens an HTTP connection to the head at the beginning of training, and then only uses that connection at the start of each training epoch. So, if Istio is enabled and if an epoch lasts longer than an hour, Istio will close the workers' connections, which can prevent completion of the training. See [this Jira ticket](https://dominodatalab.atlassian.net/browse/DOM-36271) for more info.

**Solution**
This PR introduces the `istio.httpIdleTimeout.timeout` variable to the DCO chart. If Istio is enabled and the user provides a value for the Istio HTTP timeout, then an Istio `EnvoyFilter`(s) is created in the appropriate namespace(s) that will set the HTTP timeout of pods managed by the DCO.

**How was the solution tested?**
- I manually ran `kubectl apply -f file_that_specifies_the_envoy_filter.yaml` on an existing k8s cluster and confirmed that the HTTP timeout was correctly set on new DCO-managed pods by inspecting the Istio proxy pod config dump. I also confirmed the communication error mentioned on the "problem" section went away on a new PyTorch training workload.
- I manually tested constructing the DCO chart with various combinations of values to ensure it built the expected resources using `helm install mytest ./deploy/helm/distributed-compute-operator --dry-run --debug -f myvals.yaml`.

**References**
[Istio docs for EnvoyFilter](https://istio.io/latest/docs/reference/config/networking/envoy-filter/)
[Background/starting point for this solution](https://stackoverflow.com/questions/63843610/istio-proxy-closing-long-running-tcp-connection-after-1-hour)