### PR TITLE
RM-1617 Updated debian 10 image tag for OSRP 5.2.2

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220724-2015
+FROM quay.io/domino/debian:10.11-20220824-0934
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220724-2015
+FROM quay.io/domino/debian:10.11-20220824-0934
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
Link to JIRA: https://dominodatalab.atlassian.net/browse/RM-1617
Link to build-image CI where the new tag is built and updated here:
https://app.circleci.com/pipelines/github/cerebrotech/build-images/2450/workflows/447df1dc-f7d3-4c65-bc48-42548767ec66/jobs/194066

We have updated the debian image tag as per [OSRP process](https://dominodatalab.atlassian.net/wiki/spaces/ENG/pages/1938522147/OSRP+Process) for 5.2.2.