### PR TITLE
(5.3) Check if replicas value is nil before setting config

### DIFF
--- a/pkg/controller/components/clusterstatusupdate.go
+++ b/pkg/controller/components/clusterstatusupdate.go
@@ -8,6 +8,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -72,8 +73,9 @@ func (c *clusterStatusUpdateComponent) Reconcile(ctx *core.Context) (ctrl.Result
 		csc.WorkerSelector = selector.String()
 		modified = true
 	}
-	if csc.WorkerReplicas != *sts.Spec.Replicas { // NOTE: panic: runtime error: invalid memory address or nil pointer dereference
-		csc.WorkerReplicas = *sts.Spec.Replicas
+	replicas := pointer.Int32Deref(sts.Spec.Replicas, 0)
+	if csc.WorkerReplicas != replicas { // NOTE: panic: runtime error: invalid memory address or nil pointer dereference (see DOM-40865)
+		csc.WorkerReplicas = replicas
 		modified = true
 	}
 


### PR DESCRIPTION
### Description
We used to have 
```
if csc.WorkerReplicas != *sts.Spec.Replicas { // NOTE: panic: runtime error: invalid memory address or nil pointer dereference
	csc.WorkerReplicas = *sts.Spec.Replicas
	modified = true
}
```
If `sts.Spec.Replicas` is `nil`, this code will try to dereference the `nil` pointer. It appears like some changes made in the 5.3 timeline for hybrid may leave the value as `nil` when it is 0, so the fix is just to default the pointer to 0.

### Jira
https://dominodatalab.atlassian.net/browse/DOM-40865