### PR TITLE
RM-1554 Updated debian 10 image tag for OSRP 5.3.0

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220824-0934
+FROM quay.io/domino/debian:10.11-20220914-0744
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220824-0934
+FROM quay.io/domino/debian:10.11-20220914-0744
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
Link to Jira: https://dominodatalab.atlassian.net/browse/RM-1554
Update of Debian 10 image for OSRP 5.3.0 as per [OSRP process](https://dominodatalab.atlassian.net/wiki/spaces/ENG/pages/1938522147/OSRP+Process)
Link to the build-image Circle CI run: https://app.circleci.com/pipelines/github/cerebrotech/build-images/2575/workflows/2e7ed326-4ef0-4948-8235-eacce1cfab0a/jobs/208087