### PR TITLE
RM-1554 Updated debian 10 image tag for OSRP 5.3.0 (#122)

### DIFF
--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -60,7 +60,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-20220724-2015
+FROM quay.io/domino/debian:10.11-20220914-0744
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-20220724-2015
+FROM quay.io/domino/debian:10.11-20220914-0744
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
### brings #122 from `main` to `releases-5.3.0` so that we can create a new `v0.6.5-20220914` release with ONLY the 5.3.0 OSRP updates.

* Updates Debian 10 image for 5.3.0  OSRP  -- only the *-MPi-* images are affected.

Co-authored-by: Keshav Ray <keshavray@ScaleWorx.local>