### PR TITLE
HBD-505 Dynamically set dashboard namespace selector

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -45,7 +45,7 @@ type NetworkPolicyConfig struct {
 	ClientLabels map[string]string `json:"clientLabels,omitempty"`
 	// Defines the pod selector clause that grants ingress
 	// access to the cluster dashboard.
-	DashboardPodLabels map[string]string `json:"dashboardPodLabels,omitempty"`
+	DashboardLabels map[string]string `json:"dashboardLabels,omitempty"`
 	// Defines the namespace selector clause that grants ingress
 	// access to the cluster dashboard.
 	DashboardNamespaceLabels map[string]string `json:"dashboardNamespaceLabels,omitempty"`

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -45,7 +45,8 @@ type NetworkPolicyConfig struct {
 	ClientLabels map[string]string `json:"clientLabels,omitempty"`
 	// DashboardLabels defines the pod selector clause that grants ingress
 	// access to the cluster dashboard port.
-	DashboardLabels map[string]string `json:"dashboardLabels,omitempty"`
+	DashboardPodLabels       map[string]string `json:"dashboardPodLabels,omitempty"`
+	DashboardNamespaceLabels map[string]string `json:"dashboardNamespaceLabels,omitempty"`
 }
 
 // OCIImageDefinition describes where and how to fetch a container image.

--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -43,9 +43,11 @@ type NetworkPolicyConfig struct {
 	// ClientLabels defines the pod selector clause that grants ingress access
 	// to the cluster client port(s).
 	ClientLabels map[string]string `json:"clientLabels,omitempty"`
-	// DashboardLabels defines the pod selector clause that grants ingress
-	// access to the cluster dashboard port.
-	DashboardPodLabels       map[string]string `json:"dashboardPodLabels,omitempty"`
+	// Defines the pod selector clause that grants ingress
+	// access to the cluster dashboard.
+	DashboardPodLabels map[string]string `json:"dashboardPodLabels,omitempty"`
+	// Defines the namespace selector clause that grants ingress
+	// access to the cluster dashboard.
 	DashboardNamespaceLabels map[string]string `json:"dashboardNamespaceLabels,omitempty"`
 }
 

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -20,7 +20,7 @@ var (
 
 	daskDefaultWorkerReplicas      = pointer.Int32(1)
 	daskDefaultEnableNetworkPolicy = pointer.Bool(true)
-	daskDefaultNetworkPolicyLabels = map[string]string{
+	daskDefaultNetworkPolicyPodLabels = map[string]string{
 		"dask-client": "true",
 	}
 
@@ -80,12 +80,12 @@ func (dc *DaskCluster) Default() {
 		spec.NetworkPolicy.Enabled = daskDefaultEnableNetworkPolicy
 	}
 	if spec.NetworkPolicy.ClientLabels == nil {
-		log.Info("Setting default network policy client labels", "values", daskDefaultNetworkPolicyLabels)
-		spec.NetworkPolicy.ClientLabels = daskDefaultNetworkPolicyLabels
+		log.Info("Setting default network policy client labels", "values", daskDefaultNetworkPolicyPodLabels)
+		spec.NetworkPolicy.ClientLabels = daskDefaultNetworkPolicyPodLabels
 	}
 	if spec.NetworkPolicy.DashboardPodLabels == nil {
-		log.Info("Setting default network policy dashboard labels", "values", daskDefaultNetworkPolicyLabels)
-		spec.NetworkPolicy.DashboardPodLabels = daskDefaultNetworkPolicyLabels
+		log.Info("Setting default network policy dashboard pod labels", "values", daskDefaultNetworkPolicyPodLabels)
+		spec.NetworkPolicy.DashboardPodLabels = daskDefaultNetworkPolicyPodLabels
 	}
 }
 

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -18,8 +18,8 @@ var (
 	daskDefaultWorkerPort    int32 = 3000
 	daskDefaultNannyPort     int32 = 3001
 
-	daskDefaultWorkerReplicas      = pointer.Int32(1)
-	daskDefaultEnableNetworkPolicy = pointer.Bool(true)
+	daskDefaultWorkerReplicas         = pointer.Int32(1)
+	daskDefaultEnableNetworkPolicy    = pointer.Bool(true)
 	daskDefaultNetworkPolicyPodLabels = map[string]string{
 		"dask-client": "true",
 	}

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -83,9 +83,9 @@ func (dc *DaskCluster) Default() {
 		log.Info("Setting default network policy client labels", "values", daskDefaultNetworkPolicyPodLabels)
 		spec.NetworkPolicy.ClientLabels = daskDefaultNetworkPolicyPodLabels
 	}
-	if spec.NetworkPolicy.DashboardPodLabels == nil {
+	if spec.NetworkPolicy.DashboardLabels == nil {
 		log.Info("Setting default network policy dashboard pod labels", "values", daskDefaultNetworkPolicyPodLabels)
-		spec.NetworkPolicy.DashboardPodLabels = daskDefaultNetworkPolicyPodLabels
+		spec.NetworkPolicy.DashboardLabels = daskDefaultNetworkPolicyPodLabels
 	}
 }
 

--- a/api/v1alpha1/daskcluster_webhook.go
+++ b/api/v1alpha1/daskcluster_webhook.go
@@ -83,9 +83,9 @@ func (dc *DaskCluster) Default() {
 		log.Info("Setting default network policy client labels", "values", daskDefaultNetworkPolicyLabels)
 		spec.NetworkPolicy.ClientLabels = daskDefaultNetworkPolicyLabels
 	}
-	if spec.NetworkPolicy.DashboardLabels == nil {
+	if spec.NetworkPolicy.DashboardPodLabels == nil {
 		log.Info("Setting default network policy dashboard labels", "values", daskDefaultNetworkPolicyLabels)
-		spec.NetworkPolicy.DashboardLabels = daskDefaultNetworkPolicyLabels
+		spec.NetworkPolicy.DashboardPodLabels = daskDefaultNetworkPolicyLabels
 	}
 }
 

--- a/api/v1alpha1/raycluster_webhook.go
+++ b/api/v1alpha1/raycluster_webhook.go
@@ -93,9 +93,9 @@ func (rc *RayCluster) Default() {
 		log.Info("Setting default network policy client server labels", "value", rayDefaultNetworkPolicyLabels)
 		rc.Spec.NetworkPolicy.ClientLabels = rayDefaultNetworkPolicyLabels
 	}
-	if spec.NetworkPolicy.DashboardLabels == nil {
+	if spec.NetworkPolicy.DashboardPodLabels == nil {
 		log.Info("Setting default network policy dashboard labels", "value", rayDefaultNetworkPolicyLabels)
-		rc.Spec.NetworkPolicy.DashboardLabels = rayDefaultNetworkPolicyLabels
+		rc.Spec.NetworkPolicy.DashboardPodLabels = rayDefaultNetworkPolicyLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *rayDefaultWorkerReplicas)

--- a/api/v1alpha1/raycluster_webhook.go
+++ b/api/v1alpha1/raycluster_webhook.go
@@ -93,9 +93,9 @@ func (rc *RayCluster) Default() {
 		log.Info("Setting default network policy client server labels", "value", rayDefaultNetworkPolicyPodLabels)
 		rc.Spec.NetworkPolicy.ClientLabels = rayDefaultNetworkPolicyPodLabels
 	}
-	if spec.NetworkPolicy.DashboardPodLabels == nil {
+	if spec.NetworkPolicy.DashboardLabels == nil {
 		log.Info("Setting default network policy dashboard pod labels", "value", rayDefaultNetworkPolicyPodLabels)
-		rc.Spec.NetworkPolicy.DashboardPodLabels = rayDefaultNetworkPolicyPodLabels
+		rc.Spec.NetworkPolicy.DashboardLabels = rayDefaultNetworkPolicyPodLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *rayDefaultWorkerReplicas)

--- a/api/v1alpha1/raycluster_webhook.go
+++ b/api/v1alpha1/raycluster_webhook.go
@@ -23,7 +23,7 @@ var (
 	rayDefaultEnableDashboard           = pointer.BoolPtr(true)
 	rayDefaultEnableNetworkPolicy       = pointer.BoolPtr(true)
 	rayDefaultWorkerReplicas            = pointer.Int32Ptr(1)
-	rayDefaultNetworkPolicyLabels       = map[string]string{
+	rayDefaultNetworkPolicyPodLabels       = map[string]string{
 		"ray-client": "true",
 	}
 
@@ -90,12 +90,12 @@ func (rc *RayCluster) Default() {
 		rc.Spec.NetworkPolicy.Enabled = rayDefaultEnableNetworkPolicy
 	}
 	if spec.NetworkPolicy.ClientLabels == nil {
-		log.Info("Setting default network policy client server labels", "value", rayDefaultNetworkPolicyLabels)
-		rc.Spec.NetworkPolicy.ClientLabels = rayDefaultNetworkPolicyLabels
+		log.Info("Setting default network policy client server labels", "value", rayDefaultNetworkPolicyPodLabels)
+		rc.Spec.NetworkPolicy.ClientLabels = rayDefaultNetworkPolicyPodLabels
 	}
 	if spec.NetworkPolicy.DashboardPodLabels == nil {
-		log.Info("Setting default network policy dashboard labels", "value", rayDefaultNetworkPolicyLabels)
-		rc.Spec.NetworkPolicy.DashboardPodLabels = rayDefaultNetworkPolicyLabels
+		log.Info("Setting default network policy dashboard pod labels", "value", rayDefaultNetworkPolicyPodLabels)
+		rc.Spec.NetworkPolicy.DashboardPodLabels = rayDefaultNetworkPolicyPodLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *rayDefaultWorkerReplicas)

--- a/api/v1alpha1/raycluster_webhook.go
+++ b/api/v1alpha1/raycluster_webhook.go
@@ -13,16 +13,16 @@ import (
 )
 
 var (
-	rayDefaultRedisPort           int32 = 6379
-	rayDefaultClientServerPort    int32 = 10001
-	rayDefaultObjectManagerPort   int32 = 2384
-	rayDefaultNodeManagerPort     int32 = 2385
-	rayDefaultGCSServerPort       int32 = 2386
-	rayDefaultDashboardPort       int32 = 8265
-	rayDefaultRedisShardPorts           = []int32{6380, 6381}
-	rayDefaultEnableDashboard           = pointer.BoolPtr(true)
-	rayDefaultEnableNetworkPolicy       = pointer.BoolPtr(true)
-	rayDefaultWorkerReplicas            = pointer.Int32Ptr(1)
+	rayDefaultRedisPort              int32 = 6379
+	rayDefaultClientServerPort       int32 = 10001
+	rayDefaultObjectManagerPort      int32 = 2384
+	rayDefaultNodeManagerPort        int32 = 2385
+	rayDefaultGCSServerPort          int32 = 2386
+	rayDefaultDashboardPort          int32 = 8265
+	rayDefaultRedisShardPorts              = []int32{6380, 6381}
+	rayDefaultEnableDashboard              = pointer.BoolPtr(true)
+	rayDefaultEnableNetworkPolicy          = pointer.BoolPtr(true)
+	rayDefaultWorkerReplicas               = pointer.Int32Ptr(1)
 	rayDefaultNetworkPolicyPodLabels       = map[string]string{
 		"ray-client": "true",
 	}

--- a/api/v1alpha1/raycluster_webhook_integration_test.go
+++ b/api/v1alpha1/raycluster_webhook_integration_test.go
@@ -93,9 +93,9 @@ var _ = Describe("RayCluster", func() {
 				Equal(map[string]string{"ray-client": "true"}),
 				`network policy client labels should equal [{"ray-client": "true"}]`,
 			)
-			Expect(rc.Spec.NetworkPolicy.DashboardLabels).To(
+			Expect(rc.Spec.NetworkPolicy.DashboardPodLabels).To(
 				Equal(map[string]string{"ray-client": "true"}),
-				`network policy dashboard labels should equal [{"ray-client": "true"}]`,
+				`network policy dashboard pod labels should equal [{"ray-client": "true"}]`,
 			)
 			Expect(rc.Spec.Worker.Replicas).To(
 				PointTo(BeNumerically("==", 1)),
@@ -186,10 +186,10 @@ var _ = Describe("RayCluster", func() {
 				rc := rayFixture(testNS.Name)
 
 				expected := map[string]string{"dashboard-client": "true"}
-				rc.Spec.NetworkPolicy.DashboardLabels = expected
+				rc.Spec.NetworkPolicy.DashboardPodLabels = expected
 
 				Expect(k8sClient.Create(ctx, rc)).To(Succeed())
-				Expect(rc.Spec.NetworkPolicy.DashboardLabels).To(Equal(expected))
+				Expect(rc.Spec.NetworkPolicy.DashboardPodLabels).To(Equal(expected))
 			})
 		})
 	})

--- a/api/v1alpha1/raycluster_webhook_integration_test.go
+++ b/api/v1alpha1/raycluster_webhook_integration_test.go
@@ -93,7 +93,7 @@ var _ = Describe("RayCluster", func() {
 				Equal(map[string]string{"ray-client": "true"}),
 				`network policy client labels should equal [{"ray-client": "true"}]`,
 			)
-			Expect(rc.Spec.NetworkPolicy.DashboardPodLabels).To(
+			Expect(rc.Spec.NetworkPolicy.DashboardLabels).To(
 				Equal(map[string]string{"ray-client": "true"}),
 				`network policy dashboard pod labels should equal [{"ray-client": "true"}]`,
 			)
@@ -186,10 +186,10 @@ var _ = Describe("RayCluster", func() {
 				rc := rayFixture(testNS.Name)
 
 				expected := map[string]string{"dashboard-client": "true"}
-				rc.Spec.NetworkPolicy.DashboardPodLabels = expected
+				rc.Spec.NetworkPolicy.DashboardLabels = expected
 
 				Expect(k8sClient.Create(ctx, rc)).To(Succeed())
-				Expect(rc.Spec.NetworkPolicy.DashboardPodLabels).To(Equal(expected))
+				Expect(rc.Spec.NetworkPolicy.DashboardLabels).To(Equal(expected))
 			})
 		})
 	})

--- a/api/v1alpha1/sparkcluster_webhook.go
+++ b/api/v1alpha1/sparkcluster_webhook.go
@@ -69,9 +69,9 @@ func (sc *SparkCluster) Default() {
 		log.Info("Setting default network policy client labels", "value", sparkDefaultNetworkPolicyClientPodLabels)
 		spec.NetworkPolicy.ClientLabels = sparkDefaultNetworkPolicyClientPodLabels
 	}
-	if spec.NetworkPolicy.DashboardPodLabels == nil {
+	if spec.NetworkPolicy.DashboardLabels == nil {
 		log.Info("Setting default network policy dashboard pod labels", "value", sparkDefaultNetworkPolicyClientPodLabels)
-		spec.NetworkPolicy.DashboardPodLabels = sparkDefaultNetworkPolicyClientPodLabels
+		spec.NetworkPolicy.DashboardLabels = sparkDefaultNetworkPolicyClientPodLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *sparkDefaultWorkerReplicas)

--- a/api/v1alpha1/sparkcluster_webhook.go
+++ b/api/v1alpha1/sparkcluster_webhook.go
@@ -21,7 +21,7 @@ var (
 	sparkDefaultDriverBlockManagerPort    int32 = 4042
 	sparkDefaultEnableNetworkPolicy             = pointer.BoolPtr(true)
 	sparkDefaultWorkerReplicas                  = pointer.Int32Ptr(1)
-	sparkDefaultNetworkPolicyClientLabels       = map[string]string{
+	sparkDefaultNetworkPolicyClientPodLabels       = map[string]string{
 		"spark-client": "true",
 	}
 	sparkDefaultImage = &OCIImageDefinition{
@@ -66,12 +66,12 @@ func (sc *SparkCluster) Default() {
 		spec.NetworkPolicy.Enabled = sparkDefaultEnableNetworkPolicy
 	}
 	if spec.NetworkPolicy.ClientLabels == nil {
-		log.Info("Setting default network policy client labels", "value", sparkDefaultNetworkPolicyClientLabels)
-		spec.NetworkPolicy.ClientLabels = sparkDefaultNetworkPolicyClientLabels
+		log.Info("Setting default network policy client labels", "value", sparkDefaultNetworkPolicyClientPodLabels)
+		spec.NetworkPolicy.ClientLabels = sparkDefaultNetworkPolicyClientPodLabels
 	}
 	if spec.NetworkPolicy.DashboardPodLabels == nil {
-		log.Info("Setting default network policy dashboard labels", "value", sparkDefaultNetworkPolicyClientLabels)
-		spec.NetworkPolicy.DashboardPodLabels = sparkDefaultNetworkPolicyClientLabels
+		log.Info("Setting default network policy dashboard pod labels", "value", sparkDefaultNetworkPolicyClientPodLabels)
+		spec.NetworkPolicy.DashboardPodLabels = sparkDefaultNetworkPolicyClientPodLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *sparkDefaultWorkerReplicas)

--- a/api/v1alpha1/sparkcluster_webhook.go
+++ b/api/v1alpha1/sparkcluster_webhook.go
@@ -13,14 +13,14 @@ import (
 )
 
 var (
-	sparkDefaultClusterPort               int32 = 7077
-	sparkDefaultMasterWebPort             int32 = 8080
-	sparkDefaultWorkerWebPort             int32 = 8081
-	sparkDefaultDriverUIPort              int32 = 4040
-	sparkDefaultDriverPort                int32 = 4041
-	sparkDefaultDriverBlockManagerPort    int32 = 4042
-	sparkDefaultEnableNetworkPolicy             = pointer.BoolPtr(true)
-	sparkDefaultWorkerReplicas                  = pointer.Int32Ptr(1)
+	sparkDefaultClusterPort                  int32 = 7077
+	sparkDefaultMasterWebPort                int32 = 8080
+	sparkDefaultWorkerWebPort                int32 = 8081
+	sparkDefaultDriverUIPort                 int32 = 4040
+	sparkDefaultDriverPort                   int32 = 4041
+	sparkDefaultDriverBlockManagerPort       int32 = 4042
+	sparkDefaultEnableNetworkPolicy                = pointer.BoolPtr(true)
+	sparkDefaultWorkerReplicas                     = pointer.Int32Ptr(1)
 	sparkDefaultNetworkPolicyClientPodLabels       = map[string]string{
 		"spark-client": "true",
 	}

--- a/api/v1alpha1/sparkcluster_webhook.go
+++ b/api/v1alpha1/sparkcluster_webhook.go
@@ -69,9 +69,9 @@ func (sc *SparkCluster) Default() {
 		log.Info("Setting default network policy client labels", "value", sparkDefaultNetworkPolicyClientLabels)
 		spec.NetworkPolicy.ClientLabels = sparkDefaultNetworkPolicyClientLabels
 	}
-	if spec.NetworkPolicy.DashboardLabels == nil {
+	if spec.NetworkPolicy.DashboardPodLabels == nil {
 		log.Info("Setting default network policy dashboard labels", "value", sparkDefaultNetworkPolicyClientLabels)
-		spec.NetworkPolicy.DashboardLabels = sparkDefaultNetworkPolicyClientLabels
+		spec.NetworkPolicy.DashboardPodLabels = sparkDefaultNetworkPolicyClientLabels
 	}
 	if spec.Worker.Replicas == nil {
 		log.Info("Setting default worker replicas", "value", *sparkDefaultWorkerReplicas)

--- a/api/v1alpha1/sparkcluster_webhook_integration_test.go
+++ b/api/v1alpha1/sparkcluster_webhook_integration_test.go
@@ -94,7 +94,7 @@ var _ = Describe("SparkCluster", func() {
 				Equal(map[string]string{"spark-client": "true"}),
 				`network policy client labels should equal [{"spark-client": "true"}]`,
 			)
-			Expect(sc.Spec.NetworkPolicy.DashboardPodLabels).To(
+			Expect(sc.Spec.NetworkPolicy.DashboardLabels).To(
 				Equal(map[string]string{"spark-client": "true"}),
 				`network policy dashboard labels should equal [{"spark-client": "true"}]`,
 			)
@@ -155,10 +155,10 @@ var _ = Describe("SparkCluster", func() {
 				sc := sparkFixture(testNS.Name)
 
 				expected := map[string]string{"dashboard-client": "true"}
-				sc.Spec.NetworkPolicy.DashboardPodLabels = expected
+				sc.Spec.NetworkPolicy.DashboardLabels = expected
 
 				Expect(k8sClient.Create(ctx, sc)).To(Succeed())
-				Expect(sc.Spec.NetworkPolicy.DashboardPodLabels).To(Equal(expected))
+				Expect(sc.Spec.NetworkPolicy.DashboardLabels).To(Equal(expected))
 			})
 		})
 	})

--- a/api/v1alpha1/sparkcluster_webhook_integration_test.go
+++ b/api/v1alpha1/sparkcluster_webhook_integration_test.go
@@ -94,7 +94,7 @@ var _ = Describe("SparkCluster", func() {
 				Equal(map[string]string{"spark-client": "true"}),
 				`network policy client labels should equal [{"spark-client": "true"}]`,
 			)
-			Expect(sc.Spec.NetworkPolicy.DashboardLabels).To(
+			Expect(sc.Spec.NetworkPolicy.DashboardPodLabels).To(
 				Equal(map[string]string{"spark-client": "true"}),
 				`network policy dashboard labels should equal [{"spark-client": "true"}]`,
 			)
@@ -155,10 +155,10 @@ var _ = Describe("SparkCluster", func() {
 				sc := sparkFixture(testNS.Name)
 
 				expected := map[string]string{"dashboard-client": "true"}
-				sc.Spec.NetworkPolicy.DashboardLabels = expected
+				sc.Spec.NetworkPolicy.DashboardPodLabels = expected
 
 				Expect(k8sClient.Create(ctx, sc)).To(Succeed())
-				Expect(sc.Spec.NetworkPolicy.DashboardLabels).To(Equal(expected))
+				Expect(sc.Spec.NetworkPolicy.DashboardPodLabels).To(Equal(expected))
 			})
 		})
 	})

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -417,8 +417,8 @@ func (in *NetworkPolicyConfig) DeepCopyInto(out *NetworkPolicyConfig) {
 			(*out)[key] = val
 		}
 	}
-	if in.DashboardPodLabels != nil {
-		in, out := &in.DashboardPodLabels, &out.DashboardPodLabels
+	if in.DashboardLabels != nil {
+		in, out := &in.DashboardLabels, &out.DashboardLabels
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -417,8 +417,15 @@ func (in *NetworkPolicyConfig) DeepCopyInto(out *NetworkPolicyConfig) {
 			(*out)[key] = val
 		}
 	}
-	if in.DashboardLabels != nil {
-		in, out := &in.DashboardLabels, &out.DashboardLabels
+	if in.DashboardPodLabels != nil {
+		in, out := &in.DashboardPodLabels, &out.DashboardPodLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.DashboardNamespaceLabels != nil {
+		in, out := &in.DashboardNamespaceLabels, &out.DashboardNamespaceLabels
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
@@ -244,11 +244,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardLabels:
+                  dashboardPodLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard '
+                    description: 'DashboardPodLabels defines the pod selector clause
+                      that grants ingress access to the cluster dashboard'
+                    type: object
+                  dashboardNamespaceLabels:
+                    additionalProperties:
+                      type: string
+                    description: 'DashboardNamespaceLabels defines the namespace selector clause
+                      that grants ingress access to the cluster dashboard'
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
@@ -244,17 +244,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
+                  dashboardLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
+                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
                     description: Defines the namespace selector clause that grants
                       ingress access to the cluster dashboard.
-                    type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: Defines the pod selector clause that grants ingress
-                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_daskclusters.yaml
@@ -244,17 +244,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: 'DashboardPodLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard'
-                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardNamespaceLabels defines the namespace selector clause
-                      that grants ingress access to the cluster dashboard'
+                    description: Defines the namespace selector clause that grants
+                      ingress access to the cluster dashboard.
+                    type: object
+                  dashboardPodLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
@@ -214,17 +214,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: 'DashboardPodLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard'
-                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardNamespaceLabels defines the namespace selector clause
-                      that grants ingress access to the cluster dashboard'
+                    description: Defines the namespace selector clause that grants
+                      ingress access to the cluster dashboard.
+                    type: object
+                  dashboardPodLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
@@ -214,17 +214,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
+                  dashboardLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
+                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
                     description: Defines the namespace selector clause that grants
                       ingress access to the cluster dashboard.
-                    type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: Defines the pod selector clause that grants ingress
-                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_mpiclusters.yaml
@@ -214,11 +214,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardLabels:
+                  dashboardPodLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard '
+                    description: 'DashboardPodLabels defines the pod selector clause
+                      that grants ingress access to the cluster dashboard'
+                    type: object
+                  dashboardNamespaceLabels:
+                    additionalProperties:
+                      type: string
+                    description: 'DashboardNamespaceLabels defines the namespace selector clause
+                      that grants ingress access to the cluster dashboard'
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
@@ -3284,17 +3284,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
+                  dashboardLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
+                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
                     description: Defines the namespace selector clause that grants
                       ingress access to the cluster dashboard.
-                    type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: Defines the pod selector clause that grants ingress
-                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
@@ -3284,17 +3284,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: 'DashboardPodLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard'
-                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardNamespaceLabels defines the namespace selector clause
-                      that grants ingress access to the cluster dashboard'
+                    description: Defines the namespace selector clause that grants
+                      ingress access to the cluster dashboard.
+                    type: object
+                  dashboardPodLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_rayclusters.yaml
@@ -3284,11 +3284,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardLabels:
+                  dashboardPodLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard '
+                    description: 'DashboardPodLabels defines the pod selector clause
+                      that grants ingress access to the cluster dashboard'
+                    type: object
+                  dashboardNamespaceLabels:
+                    additionalProperties:
+                      type: string
+                    description: 'DashboardNamespaceLabels defines the namespace selector clause
+                      that grants ingress access to the cluster dashboard'
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
@@ -3311,17 +3311,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
+                  dashboardLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
+                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
                     description: Defines the namespace selector clause that grants
                       ingress access to the cluster dashboard.
-                    type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: Defines the pod selector clause that grants ingress
-                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
@@ -3311,14 +3311,17 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardLabels:
-                    restrictToPlatformNamespace:
-                      type: boolean
-                      description: Whether to restrict dashboard access to the platform namespace
+                  dashboardPodLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard '
+                    description: 'DashboardPodLabels defines the pod selector clause
+                      that grants ingress access to the cluster dashboard'
+                    type: object
+                  dashboardNamespaceLabels:
+                    additionalProperties:
+                      type: string
+                    description: 'DashboardNamespaceLabels defines the namespace selector clause
+                      that grants ingress access to the cluster dashboard'
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
@@ -3312,6 +3312,9 @@ spec:
                       grants ingress access to the cluster client port(s
                     type: object
                   dashboardLabels:
+                    restrictToPlatformNamespace:
+                      type: boolean
+                      description: Whether to restrict dashboard access to the platform namespace
                     additionalProperties:
                       type: string
                     description: 'DashboardLabels defines the pod selector clause
@@ -3319,7 +3322,7 @@ spec:
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies
-                      that limit and provide ingress access to the clust
+                      that limit and provide ingress access to the cluster
                     type: boolean
                 type: object
               podSecurityContext:

--- a/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
+++ b/config/crd/bases/distributed-compute.dominodatalab.com_sparkclusters.yaml
@@ -3311,21 +3311,21 @@ spec:
                     description: ClientLabels defines the pod selector clause that
                       grants ingress access to the cluster client port(s
                     type: object
-                  dashboardPodLabels:
-                    additionalProperties:
-                      type: string
-                    description: 'DashboardPodLabels defines the pod selector clause
-                      that grants ingress access to the cluster dashboard'
-                    type: object
                   dashboardNamespaceLabels:
                     additionalProperties:
                       type: string
-                    description: 'DashboardNamespaceLabels defines the namespace selector clause
-                      that grants ingress access to the cluster dashboard'
+                    description: Defines the namespace selector clause that grants
+                      ingress access to the cluster dashboard.
+                    type: object
+                  dashboardPodLabels:
+                    additionalProperties:
+                      type: string
+                    description: Defines the pod selector clause that grants ingress
+                      access to the cluster dashboard.
                     type: object
                   enabled:
                     description: Enabled controls the creation of network policies
-                      that limit and provide ingress access to the cluster
+                      that limit and provide ingress access to the clust
                     type: boolean
                 type: object
               podSecurityContext:

--- a/config/samples/distributed-compute_v1alpha1_daskcluster.yaml
+++ b/config/samples/distributed-compute_v1alpha1_daskcluster.yaml
@@ -24,7 +24,8 @@ spec:
   # networkPolicy:
   #   enabled: true
   #   clientLabels: {}
-  #   dashboardLabels: {}
+  #   dashboardPodLabels: {}
+  #   dashboardNamespaceLabels: {}
 
   # serviceAccount:
   #   name: ""

--- a/config/samples/distributed-compute_v1alpha1_daskcluster.yaml
+++ b/config/samples/distributed-compute_v1alpha1_daskcluster.yaml
@@ -24,7 +24,7 @@ spec:
   # networkPolicy:
   #   enabled: true
   #   clientLabels: {}
-  #   dashboardPodLabels: {}
+  #   dashboardLabels: {}
   #   dashboardNamespaceLabels: {}
 
   # serviceAccount:

--- a/config/samples/distributed-compute_v1alpha1_raycluster.yaml
+++ b/config/samples/distributed-compute_v1alpha1_raycluster.yaml
@@ -46,7 +46,8 @@ spec:
   # networkPolicy:
   #   enabled: true
   #   clientLabels: {}
-  #   dashboardLabels: {}
+  #   dashboardPodLabels: {}
+  #   dashboardNamespaceLabels: {}
 
   # serviceAccount:
   #   name: ""

--- a/config/samples/distributed-compute_v1alpha1_raycluster.yaml
+++ b/config/samples/distributed-compute_v1alpha1_raycluster.yaml
@@ -46,7 +46,7 @@ spec:
   # networkPolicy:
   #   enabled: true
   #   clientLabels: {}
-  #   dashboardPodLabels: {}
+  #   dashboardLabels: {}
   #   dashboardNamespaceLabels: {}
 
   # serviceAccount:

--- a/deploy/helm/distributed-compute-operator/dco-values.yaml
+++ b/deploy/helm/distributed-compute-operator/dco-values.yaml
@@ -1,0 +1,44 @@
+USER-SUPPLIED VALUES:
+image:
+  registry: quay.io
+  repository: domino/distributed-compute-operator
+  tag: v0.6.5
+  pullPolicy: Always
+imagePullSecrets:
+- name: domino-quay-repos
+installCRDs: true
+istio:
+  cni: true
+  enabled: false
+  httpIdleTimeout:
+    timeout: 24h
+  install: false
+  rootConfigNamespace: istio-system
+mpi:
+  initImage:
+    registry: quay.io
+    repository: domino/distributed-compute-operator-mpi-init
+    tag: v0.6.5
+  syncImage:
+    registry: quay.io
+    repository: domino/distributed-compute-operator-mpi-sync
+    tag: v0.6.5
+networkPolicy:
+  enabled: true
+nodeSelector:
+  dominodatalab.com/node-pool: default
+podAnnotations: {}
+podEnv: []
+podLabels: {}
+podSecurityPolicy:
+  enabled: true
+priorityClassName: domino-default
+prometheus:
+  enabled: true
+  namespaceLabels:
+    domino-platform: "true"
+rbac:
+  pspEnabled: true
+replicaCount: 1
+securityContextConstraints:
+  enabled: false

--- a/pkg/cluster/dask/dask_test.go
+++ b/pkg/cluster/dask/dask_test.go
@@ -28,7 +28,7 @@ func testDaskCluster() *dcv1alpha1.DaskCluster {
 						ClientLabels: map[string]string{
 							"test-client": "true",
 						},
-						DashboardPodLabels: map[string]string{
+						DashboardLabels: map[string]string{
 							"test-ui-client": "true",
 						},
 						DashboardNamespaceLabels: map[string]string{

--- a/pkg/cluster/dask/dask_test.go
+++ b/pkg/cluster/dask/dask_test.go
@@ -28,8 +28,11 @@ func testDaskCluster() *dcv1alpha1.DaskCluster {
 						ClientLabels: map[string]string{
 							"test-client": "true",
 						},
-						DashboardLabels: map[string]string{
+						DashboardPodLabels: map[string]string{
 							"test-ui-client": "true",
+						},
+						DashboardNamespaceLabels: map[string]string{
+							"domino-platform": "true",
 						},
 					},
 					PodSecurityPolicy: "privileged",

--- a/pkg/cluster/dask/networkpolicy.go
+++ b/pkg/cluster/dask/networkpolicy.go
@@ -86,7 +86,10 @@ func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule
 				From: []networkingv1.NetworkPolicyPeer{
 					{
 						PodSelector: &metav1.LabelSelector{
-							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardLabels,
+							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardPodLabels,
+						},
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardNamespaceLabels,
 						},
 					},
 				},
@@ -148,7 +151,10 @@ func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule
 				},
 				{
 					PodSelector: &metav1.LabelSelector{
-						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardLabels,
+						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardPodLabels,
+					},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardNamespaceLabels,
 					},
 				},
 			},

--- a/pkg/cluster/dask/networkpolicy.go
+++ b/pkg/cluster/dask/networkpolicy.go
@@ -86,7 +86,7 @@ func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule
 				From: []networkingv1.NetworkPolicyPeer{
 					{
 						PodSelector: &metav1.LabelSelector{
-							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardPodLabels,
+							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardLabels,
 						},
 						NamespaceSelector: &metav1.LabelSelector{
 							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardNamespaceLabels,
@@ -151,7 +151,7 @@ func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule
 				},
 				{
 					PodSelector: &metav1.LabelSelector{
-						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardPodLabels,
+						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardLabels,
 					},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: s.dc.Spec.NetworkPolicy.DashboardNamespaceLabels,

--- a/pkg/cluster/dask/networkpolicy.go
+++ b/pkg/cluster/dask/networkpolicy.go
@@ -57,11 +57,6 @@ func (s *networkPolicyDS) Delete() bool {
 func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule {
 	tcpProto := corev1.ProtocolTCP
 	dashboardPort := intstr.FromInt(int(s.dc.Spec.DashboardPort))
-	namespaceSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"domino-platform": "true",
-		},
-	}
 
 	if s.comp == ComponentScheduler {
 		sPort := intstr.FromInt(int(s.dc.Spec.SchedulerPort))
@@ -93,7 +88,6 @@ func (s *networkPolicyDS) ingressRules() []networkingv1.NetworkPolicyIngressRule
 						PodSelector: &metav1.LabelSelector{
 							MatchLabels: s.dc.Spec.NetworkPolicy.DashboardLabels,
 						},
-						NamespaceSelector: &namespaceSelector,
 					},
 				},
 				Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/cluster/dask/networkpolicy_test.go
+++ b/pkg/cluster/dask/networkpolicy_test.go
@@ -82,11 +82,6 @@ func TestNetworkPolicyDS_NetworkPolicy(t *testing.T) {
 										"test-ui-client": "true",
 									},
 								},
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										"domino-platform": "true",
-									},
-								},
 							},
 						},
 					},

--- a/pkg/cluster/dask/networkpolicy_test.go
+++ b/pkg/cluster/dask/networkpolicy_test.go
@@ -82,6 +82,11 @@ func TestNetworkPolicyDS_NetworkPolicy(t *testing.T) {
 										"test-ui-client": "true",
 									},
 								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"domino-platform": "true",
+									},
+								},
 							},
 						},
 					},
@@ -190,6 +195,11 @@ func TestNetworkPolicyDS_NetworkPolicy(t *testing.T) {
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										"test-ui-client": "true",
+									},
+								},
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"domino-platform": "true",
 									},
 								},
 							},

--- a/pkg/resources/ray/networkpolicy.go
+++ b/pkg/resources/ray/networkpolicy.go
@@ -57,7 +57,7 @@ func NewHeadClientNetworkPolicy(rc *dcv1alpha1.RayCluster) *networkingv1.Network
 	return headNetworkPolicy(
 		rc,
 		rc.Spec.ClientServerPort,
-		rc.Spec.NetworkPolicy.ClientLabels,
+		rc.Spec.NetworkPolicy,
 		Component("client"),
 		descriptionClient,
 	)
@@ -70,13 +70,13 @@ func NewHeadDashboardNetworkPolicy(rc *dcv1alpha1.RayCluster) *networkingv1.Netw
 	return headNetworkPolicy(
 		rc,
 		rc.Spec.DashboardPort,
-		rc.Spec.NetworkPolicy.DashboardLabels,
+		rc.Spec.NetworkPolicy,
 		Component("dashboard"),
 		descriptionDashboard,
 	)
 }
 
-func headNetworkPolicy(rc *dcv1alpha1.RayCluster, p int32, l map[string]string, c Component, desc string) *networkingv1.NetworkPolicy {
+func headNetworkPolicy(rc *dcv1alpha1.RayCluster, p int32, netPol dcv1alpha1.NetworkPolicyConfig, c Component, desc string) *networkingv1.NetworkPolicy {
 	proto := corev1.ProtocolTCP
 	targetPort := intstr.FromInt(int(p))
 
@@ -104,7 +104,10 @@ func headNetworkPolicy(rc *dcv1alpha1.RayCluster, p int32, l map[string]string, 
 					From: []networkingv1.NetworkPolicyPeer{
 						{
 							PodSelector: &metav1.LabelSelector{
-								MatchLabels: l,
+								MatchLabels: netPol.DashboardPodLabels,
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: netPol.DashboardNamespaceLabels,
 							},
 						},
 					},

--- a/pkg/resources/ray/networkpolicy.go
+++ b/pkg/resources/ray/networkpolicy.go
@@ -78,12 +78,17 @@ func NewHeadDashboardNetworkPolicy(rc *dcv1alpha1.RayCluster) *networkingv1.Netw
 	)
 }
 
-func headNetworkPolicy(rc *dcv1alpha1.RayCluster, p int32, pl map[string]string, nl map[string]string, c Component, desc string) *networkingv1.NetworkPolicy {
+func headNetworkPolicy(
+	rc *dcv1alpha1.RayCluster,
+	p int32,
+	pl map[string]string,
+	nl map[string]string,
+	c Component,
+	desc string,
+) *networkingv1.NetworkPolicy {
+	
 	proto := corev1.ProtocolTCP
 	targetPort := intstr.FromInt(int(p))
-
-	test := networkingv1.NetworkPolicySpec{}
-	test.Ingress = append(test.Ingress)
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resources/ray/networkpolicy.go
+++ b/pkg/resources/ray/networkpolicy.go
@@ -71,7 +71,7 @@ func NewHeadDashboardNetworkPolicy(rc *dcv1alpha1.RayCluster) *networkingv1.Netw
 	return headNetworkPolicy(
 		rc,
 		rc.Spec.DashboardPort,
-		rc.Spec.NetworkPolicy.DashboardPodLabels,
+		rc.Spec.NetworkPolicy.DashboardLabels,
 		rc.Spec.NetworkPolicy.DashboardNamespaceLabels,
 		Component("dashboard"),
 		descriptionDashboard,

--- a/pkg/resources/ray/networkpolicy.go
+++ b/pkg/resources/ray/networkpolicy.go
@@ -86,7 +86,6 @@ func headNetworkPolicy(
 	c Component,
 	desc string,
 ) *networkingv1.NetworkPolicy {
-	
 	proto := corev1.ProtocolTCP
 	targetPort := intstr.FromInt(int(p))
 

--- a/pkg/resources/ray/networkpolicy_test.go
+++ b/pkg/resources/ray/networkpolicy_test.go
@@ -108,6 +108,9 @@ func TestNewHeadClientNetworkPolicy(t *testing.T) {
 									"server-client": "true",
 								},
 							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{},
+							},
 						},
 					},
 				},
@@ -123,8 +126,11 @@ func TestNewHeadClientNetworkPolicy(t *testing.T) {
 func TestNewHeadDashboardNetworkPolicy(t *testing.T) {
 	rc := rayClusterFixture()
 	rc.Spec.NetworkPolicy = dcv1alpha1.NetworkPolicyConfig{
-		DashboardLabels: map[string]string{
+		DashboardPodLabels: map[string]string{
 			"dashboard-client": "true",
+		},
+		DashboardNamespaceLabels: map[string]string{
+			"domino-platform": "true",
 		},
 	}
 	netpol := NewHeadDashboardNetworkPolicy(rc)
@@ -167,6 +173,11 @@ func TestNewHeadDashboardNetworkPolicy(t *testing.T) {
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"dashboard-client": "true",
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"domino-platform": "true",
 								},
 							},
 						},

--- a/pkg/resources/ray/networkpolicy_test.go
+++ b/pkg/resources/ray/networkpolicy_test.go
@@ -126,7 +126,7 @@ func TestNewHeadClientNetworkPolicy(t *testing.T) {
 func TestNewHeadDashboardNetworkPolicy(t *testing.T) {
 	rc := rayClusterFixture()
 	rc.Spec.NetworkPolicy = dcv1alpha1.NetworkPolicyConfig{
-		DashboardPodLabels: map[string]string{
+		DashboardLabels: map[string]string{
 			"dashboard-client": "true",
 		},
 		DashboardNamespaceLabels: map[string]string{

--- a/pkg/resources/spark/networkpolicy.go
+++ b/pkg/resources/spark/networkpolicy.go
@@ -8,7 +8,6 @@ import (
 
 	dcv1alpha1 "github.com/dominodatalab/distributed-compute-operator/api/v1alpha1"
 	"github.com/dominodatalab/distributed-compute-operator/pkg/resources"
-	"github.com/dominodatalab/distributed-compute-operator/pkg/util"
 )
 
 func NewClusterWorkerNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.NetworkPolicy {
@@ -123,19 +122,12 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		MatchLabels: MetadataLabelsWithComponent(sc, ComponentWorker),
 	}
 
-	dashboardSelector := metav1.LabelSelector{
-		MatchLabels: sc.Spec.NetworkPolicy.DashboardLabels,
+	dashboardPodSelector := metav1.LabelSelector{
+		MatchLabels: sc.Spec.NetworkPolicy.DashboardPodLabels,
 	}
 
-	var namespaceSelector = metav1.LabelSelector{ 
-		MatchLabels: map[string]string{ "": "" },
-	}
-	if !util.BoolPtrIsTrue(sc.Spec.NetworkPolicy.DashboardLabels.RestrictToPlatformNamespace) {
-		namespaceSelector = metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"domino-platform": "true",
-			},
-		}
+	dashboardNamespaceSelector := metav1.LabelSelector{
+		MatchLabels: sc.Spec.NetworkPolicy.DashboardNamespaceLabels,
 	}
 
 	protocol := corev1.ProtocolTCP
@@ -173,8 +165,8 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 				{
 					From: []networkingv1.NetworkPolicyPeer{
 						{
-							PodSelector:       &dashboardSelector,
-							NamespaceSelector: &namespaceSelector,
+							PodSelector:       &dashboardPodSelector,
+							NamespaceSelector: &dashboardNamespaceSelector,
 						},
 					},
 					Ports: []networkingv1.NetworkPolicyPort{

--- a/pkg/resources/spark/networkpolicy.go
+++ b/pkg/resources/spark/networkpolicy.go
@@ -126,12 +126,6 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 		MatchLabels: sc.Spec.NetworkPolicy.DashboardLabels,
 	}
 
-	namespaceSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			"domino-platform": "true",
-		},
-	}
-
 	protocol := corev1.ProtocolTCP
 	masterDashboardPort := intstr.FromInt(int(sc.Spec.MasterWebPort))
 	clusterPort := intstr.FromInt(int(sc.Spec.ClusterPort))
@@ -167,7 +161,6 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 				{
 					From: []networkingv1.NetworkPolicyPeer{
 						{
-							NamespaceSelector: &namespaceSelector,
 							PodSelector:       &dashboardSelector,
 						},
 					},

--- a/pkg/resources/spark/networkpolicy.go
+++ b/pkg/resources/spark/networkpolicy.go
@@ -123,7 +123,7 @@ func NewClusterMasterNetworkPolicy(sc *dcv1alpha1.SparkCluster) *networkingv1.Ne
 	}
 
 	dashboardPodSelector := metav1.LabelSelector{
-		MatchLabels: sc.Spec.NetworkPolicy.DashboardPodLabels,
+		MatchLabels: sc.Spec.NetworkPolicy.DashboardLabels,
 	}
 
 	dashboardNamespaceSelector := metav1.LabelSelector{

--- a/pkg/resources/spark/networkpolicy_test.go
+++ b/pkg/resources/spark/networkpolicy_test.go
@@ -209,11 +209,6 @@ func TestNewClusterMasterNetworkPolicy(t *testing.T) {
 				{
 					From: []networkingv1.NetworkPolicyPeer{
 						{
-							NamespaceSelector: &metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"domino-platform": "true",
-								},
-							},
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"spark-client": "true",

--- a/pkg/resources/spark/networkpolicy_test.go
+++ b/pkg/resources/spark/networkpolicy_test.go
@@ -145,7 +145,7 @@ func TestNewClusterWorkerNetworkPolicy(t *testing.T) {
 func TestNewClusterMasterNetworkPolicy(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.NetworkPolicy.ClientLabels = map[string]string{"app.kubernetes.io/instance": "spark-driver"}
-	rc.Spec.NetworkPolicy.DashboardPodLabels = map[string]string{"spark-client": "true"}
+	rc.Spec.NetworkPolicy.DashboardLabels = map[string]string{"spark-client": "true"}
 	rc.Spec.NetworkPolicy.DashboardNamespaceLabels = map[string]string{"domino-platform": "true"}
 
 	netpol := NewClusterMasterNetworkPolicy(rc)

--- a/pkg/resources/spark/networkpolicy_test.go
+++ b/pkg/resources/spark/networkpolicy_test.go
@@ -145,7 +145,8 @@ func TestNewClusterWorkerNetworkPolicy(t *testing.T) {
 func TestNewClusterMasterNetworkPolicy(t *testing.T) {
 	rc := sparkClusterFixture()
 	rc.Spec.NetworkPolicy.ClientLabels = map[string]string{"app.kubernetes.io/instance": "spark-driver"}
-	rc.Spec.NetworkPolicy.DashboardLabels = map[string]string{"spark-client": "true"}
+	rc.Spec.NetworkPolicy.DashboardPodLabels = map[string]string{"spark-client": "true"}
+	rc.Spec.NetworkPolicy.DashboardNamespaceLabels = map[string]string{"domino-platform": "true"}
 
 	netpol := NewClusterMasterNetworkPolicy(rc)
 
@@ -212,6 +213,11 @@ func TestNewClusterMasterNetworkPolicy(t *testing.T) {
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
 									"spark-client": "true",
+								},
+							},
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"domino-platform": "true",
 								},
 							},
 						},


### PR DESCRIPTION
### Description
Currently the network policy allowing access to the cluster ui utilizes the hardcoded value `domino-platform` as it's namespace selector, which does not work in remote data planes where there is no platform namespace. This PR allows for setting the namespace selector dynamically instead.

### Jira
https://dominodatalab.atlassian.net/browse/HBD-505