### PR TITLE
PLAT-5844: Explicit Pod Security Contexts

### DIFF
--- a/deploy/helm/distributed-compute-operator/values.yaml
+++ b/deploy/helm/distributed-compute-operator/values.yaml
@@ -94,6 +94,8 @@ podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
   # fsGroup: 2000
+  seLinuxOptions:
+    type: spc_t
 
 securityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
All charts must have a pod security context defined. It must include runAsNonRoot, runAsUser and seLinuxOption.