### PR TITLE
HBD-703 • Cluster destroy failures (tests only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ fmt: goimports ## Run formatter against code.
 lint: golangci-lint ## Run linters against code.
 	$(GOLANGCI_LINT) run
 
-ENVTEST_VERSION = 1.20.x!
+ENVTEST_VERSION = 1.24.x!
 ENVTEST_ASSETS_DIR = $(shell pwd)/testbin
 test: setup-envtest manifests generate fmt ## Run full test suite.
 	$(shell eval "$(SETUP_ENVTEST) --bin-dir $(ENVTEST_ASSETS_DIR) use --print env $(ENVTEST_VERSION)"); go test ./... -race -covermode atomic -coverprofile cover.out

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
@@ -22,6 +23,8 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var ctx context.Context
+var cancel context.CancelFunc
 
 func TestAPIs(t *testing.T) {
 	if testing.Short() {
@@ -34,6 +37,8 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
@@ -81,13 +86,14 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	go func() {
-		err = k8sManager.Start(ctrl.SetupSignalHandler())
+		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), err.Error())
 	}()
 }, 60)
 
 var _ = AfterSuite(func() {
+	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).ToNot(HaveOccurred())
 })

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 
 	go func() {
 		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred(), err.Error())
+		Expect(err).ToNot(HaveOccurred())
 	}()
 }, 60)
 


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/HBD-703

After upgrading to a newer version of k8s in the test environment, the DCO tests started failing. The root cause was that the test cluster has been shutting down too soon, before resources were finalized.

A recipe for this fix is from here: https://github.com/kubernetes-sigs/kubebuilder/pull/2379
