### PR TITLE
DOM-46931: provide `arm64` variant of DCO image

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,6 +100,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v4
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.docker_prep.outputs.tags }}
         cache-to: type=registry,ref=${{ steps.docker_prep.outputs.image }}:buildcache,mode=max
@@ -119,6 +120,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: "{{defaultContext}}:dockerfiles"
+        platforms: linux/amd64,linux/arm64
         file: mpi-init.Dockerfile
         push: true
         tags: ${{ steps.docker_prep.outputs.tags_mpi_init }}
@@ -137,6 +139,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: "{{defaultContext}}:dockerfiles"
+        platforms: linux/amd64,linux/arm64
         file: mpi-sync.Dockerfile
         push: true
         tags: ${{ steps.docker_prep.outputs.tags_mpi_sync }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY controllers/ controllers/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -2,7 +2,7 @@
 # of core libraries (libc etc) the compiled binaries will be linked against.
 # FYI, debian-9.13 -> libc-2.24
 # OSRP not neccessary here because it's just the build environment, see the final image FROM at the bottom
-FROM quay.io/domino/debian:9.13-20210202-2325
+FROM quay.io/domino/debian:10.11-360356
 
 ARG OPENSSH_VERSION=8.8p1
 ARG OPENSSH_URL=https://mirrors.mit.edu/pub/OpenBSD/OpenSSH/portable/openssh-${OPENSSH_VERSION}.tar.gz
@@ -61,7 +61,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-355533
+FROM quay.io/domino/debian:10.11-360356
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-355533
+FROM quay.io/domino/debian:10.11-360356
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
[DOM-46931](https://dominodatalab.atlassian.net/browse/DOM-46931)

* update all images built as part of DCO to produce `arm64` variants as
  well as `amd64`
