### PR TITLE
[DOM-49065] OSRP bump images to 0.7.3 for 5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20.3 as builder
+FROM golang:1.20.7 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/deploy/helm/distributed-compute-operator/dco-values.yaml
+++ b/deploy/helm/distributed-compute-operator/dco-values.yaml
@@ -2,7 +2,7 @@ USER-SUPPLIED VALUES:
 image:
   registry: quay.io
   repository: domino/distributed-compute-operator
-  tag: v0.7.2
+  tag: v0.7.3
   pullPolicy: Always
 imagePullSecrets:
 - name: domino-quay-repos
@@ -19,11 +19,11 @@ mpi:
   initImage:
     registry: quay.io
     repository: domino/distributed-compute-operator-mpi-init
-    tag: v0.7.2
+    tag: v0.7.3
   syncImage:
     registry: quay.io
     repository: domino/distributed-compute-operator-mpi-sync
-    tag: v0.7.2
+    tag: v0.7.3
 networkPolicy:
   enabled: true
 nodeSelector:

--- a/dockerfiles/mpi-init.Dockerfile
+++ b/dockerfiles/mpi-init.Dockerfile
@@ -2,7 +2,7 @@
 # of core libraries (libc etc) the compiled binaries will be linked against.
 # FYI, debian-9.13 -> libc-2.24
 # OSRP not neccessary here because it's just the build environment, see the final image FROM at the bottom
-FROM quay.io/domino/debian:10.11-360356
+FROM quay.io/domino/debian:10.11-368763
 
 ARG OPENSSH_VERSION=8.8p1
 ARG OPENSSH_URL=https://mirrors.mit.edu/pub/OpenBSD/OpenSSH/portable/openssh-${OPENSSH_VERSION}.tar.gz
@@ -61,7 +61,7 @@ RUN \
 
 # The final image only contains built artifacts.
 # The base image should be up-to-date, but a specific version is not important.
-FROM quay.io/domino/debian:10.11-360356
+FROM quay.io/domino/debian:10.11-368763
 WORKDIR /root
 COPY --from=0 /root/worker-utils.tgz ./
 CMD tar -C / -xf /root/worker-utils.tgz

--- a/dockerfiles/mpi-sync.Dockerfile
+++ b/dockerfiles/mpi-sync.Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/domino/debian:10.11-360356
+FROM quay.io/domino/debian:10.11-368763
 
 ARG DOMINO_UID=12574
 ARG DOMINO_USER=domino


### PR DESCRIPTION
https://dominodatalab.atlassian.net/browse/DOM-49065

 - OSRP updates did two things wrong:

    * didn't correctly produce multi-arch images
    * blew away the existing 0.7.2 tag

 - Since we can no longer trust that tag, proactively:

   * add this commit
   * update the base images in use to latest from OSRP process
   * refer to an as-of-yet-nonexistant image version
   * generate a tag to produce a 0.7.3
   * update the deployer / platform-apps repo with the new version